### PR TITLE
Resolve issue with AudioPro Link2 failing to complete mTLS exchange in time. 

### DIFF
--- a/pywiim/api/base.py
+++ b/pywiim/api/base.py
@@ -30,6 +30,9 @@ from .constants import (
     API_ENDPOINT_STATUS,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    PROBE_TIMEOUT_ASYNC,
+    PROBE_TIMEOUT_CONNECT,
+    PROBE_TIMEOUT_TOTAL,
 )
 from .parser import parse_player_status
 from .ssl import create_wiim_ssl_context
@@ -643,8 +646,7 @@ class BaseWiiMClient:
         # Build list of protocol/port combinations to try
         protocols_to_try = self._build_probe_list()
 
-        # Use short timeout for fast failure detection
-        probe_timeout = aiohttp.ClientTimeout(connect=0.5, total=min(2.0, timeout))
+        probe_timeout = aiohttp.ClientTimeout(connect=PROBE_TIMEOUT_CONNECT, total=min(PROBE_TIMEOUT_TOTAL, timeout))
 
         last_error: Exception | None = None
         tried: list[str] = []
@@ -666,7 +668,7 @@ class BaseWiiMClient:
 
             try:
                 await self._ensure_session()
-                async with asyncio.timeout(2.0):
+                async with asyncio.timeout(PROBE_TIMEOUT_ASYNC):
                     resp = await self._session_request(method, url, **test_kwargs)
                     async with resp:
                         resp.raise_for_status()

--- a/pywiim/api/constants.py
+++ b/pywiim/api/constants.py
@@ -302,6 +302,12 @@ VENDOR_LINKPLAY_GENERIC = "linkplay_generic"
 DEFAULT_PORT = 443  # HTTPS port
 DEFAULT_TIMEOUT = 5.0  # seconds
 
+# Protocol probe timeout settings
+# mTLS connections (Audio Pro MkII on port 4443) need longer timeout for certificate exchange
+PROBE_TIMEOUT_CONNECT = 1.0  # seconds - TCP connection timeout
+PROBE_TIMEOUT_TOTAL = 5.0  # seconds - total request timeout (allows time for mTLS handshake)
+PROBE_TIMEOUT_ASYNC = 5.0  # seconds - asyncio.timeout wrapper
+
 # Play mode constants
 PLAY_MODE_NORMAL = "normal"
 PLAY_MODE_REPEAT_ALL = "repeat_all"
@@ -497,6 +503,9 @@ __all__ = [
     "EQ_NUMERIC_MAP",
     "DEFAULT_PORT",
     "DEFAULT_TIMEOUT",
+    "PROBE_TIMEOUT_CONNECT",
+    "PROBE_TIMEOUT_TOTAL",
+    "PROBE_TIMEOUT_ASYNC",
     "API_ENDPOINT_STATUS",
     "API_ENDPOINT_PLAYER_STATUS",
     "API_ENDPOINT_METADATA",


### PR DESCRIPTION
Hello, 

I'm not certain you accept PRs, and you may not wish to fix this issue in this way. However i chose to raise a PR as it was illustrative of the issue.

Prior to this change wiim-diagnostics would fail to return, and then ultimately fail on timeout. This was pretty reliable behavour. quickly bumping the timeouts in this area to give a fair bit of overhead ultimately resolved this.

Now i took the step of consting (at least by python conventions) out the timeout params, mainly as we might want to rein them back in individually going forward. 

As I say, i don't want to ruffle any feathers or anything, this got me from a reliable failure to communicate to a reliable success, but perhaps theres a more elegant approach we can take