### PR TITLE
Add Audio Pro RCA input and source detection for non-standard model strings (e.g. Link 2)

### DIFF
--- a/pywiim/api/constants.py
+++ b/pywiim/api/constants.py
@@ -134,6 +134,7 @@ MODE_MAP: dict[str, str] = {
     "40": "line_in",
     "41": "bluetooth",
     "43": "optical",
+    "44": "rca",  # Audio Pro RCA line input (confirmed via tcpdump on Link 2)
     "47": "line_in_2",
     "49": "hdmi",
     "51": "usb",

--- a/pywiim/capabilities.py
+++ b/pywiim/capabilities.py
@@ -41,7 +41,7 @@ from .exceptions import WiiMError
 from .model_names import is_known_wiim_model
 from .models import DeviceInfo
 from .normalize import normalize_vendor
-from .profiles import get_device_profile
+from .profiles import detect_audio_pro_generation, detect_vendor, get_device_profile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -489,51 +489,6 @@ def detect_device_capabilities(device_info: DeviceInfo) -> dict[str, Any]:
     return capabilities
 
 
-def detect_vendor(device_info: DeviceInfo) -> str:
-    """Detect device vendor from device information.
-
-    Args:
-        device_info: Device information
-
-    Returns:
-        Normalized vendor string: "wiim", "arylic", "audio_pro", or "linkplay_generic"
-    """
-    if not device_info.model:
-        # Try device name as fallback
-        if device_info.name:
-            return normalize_vendor(device_info.name)
-        return "linkplay_generic"
-
-    model_lower = device_info.model.lower()
-    name_lower = (device_info.name or "").lower()
-
-    # WiiM devices - include known raw model aliases (e.g., "Muzo_Mini")
-    # and project variants like "WiiM_Pro_with_gc4a".
-    if is_known_wiim_model(device_info.model) or "wiim" in model_lower:
-        return "wiim"
-    if "wiim" in name_lower:
-        return "wiim"
-
-    # Arylic devices
-    if any(arylic in model_lower for arylic in ["arylic", "up2stream", "s10+"]):
-        return "arylic"
-    if "arylic" in name_lower or "up2stream" in name_lower:
-        return "arylic"
-
-    # Audio Pro devices
-    if any(pro in model_lower for pro in ["audio pro", "addon", "a10", "a15", "a28", "c10"]):
-        return "audio_pro"
-    if "audio pro" in name_lower or "addon" in name_lower:
-        return "audio_pro"
-
-    # Firmware-based fallback for Audio Pro devices with non-standard model strings
-    # (e.g. Link 2 model is "LINK 2 Wireless multiroom HiFi player" but firmware starts with "audiopro_")
-    if device_info.firmware and "audiopro" in device_info.firmware.lower():
-        return "audio_pro"
-
-    return "linkplay_generic"
-
-
 def is_wiim_device(device_info: DeviceInfo) -> bool:
     """Check if device is a WiiM device.
 
@@ -548,47 +503,6 @@ def is_wiim_device(device_info: DeviceInfo) -> bool:
 
     model_lower = device_info.model.lower()
     return is_known_wiim_model(device_info.model) or "wiim" in model_lower
-
-
-def detect_audio_pro_generation(device_info: DeviceInfo) -> str:
-    """Detect Audio Pro device generation for optimized handling.
-
-    Args:
-        device_info: Device information
-
-    Returns:
-        Generation string: "original", "mkii", "w_generation", or "unknown"
-    """
-    if not device_info.model:
-        return "unknown"
-
-    model_lower = device_info.model.lower()
-
-    # Audio Pro generation patterns
-    if any(gen in model_lower for gen in ["mkii", "mk2", "mk ii", "mark ii"]):
-        return "mkii"
-    elif any(gen in model_lower for gen in ["w-", "w series", "w generation", "w gen"]):
-        return "w_generation"
-    elif any(model in model_lower for model in ["a10", "a15", "a28", "c10", "audio pro"]):
-        # Modern Audio Pro devices (assume MkII if not specified)
-        if device_info.firmware:
-            # Try to determine from firmware version if available
-            firmware_lower = device_info.firmware.lower()
-            if any(version in firmware_lower for version in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
-                return "mkii"  # MkII firmware range
-            elif any(version in firmware_lower for version in ["2.0", "2.1", "2.2", "2.3"]):
-                return "w_generation"  # W-generation firmware range
-
-        return "mkii"  # Default to MkII for modern Audio Pro models
-    else:
-        # For unrecognized Audio Pro models (e.g. Link 2), fall back to firmware version
-        if device_info.firmware:
-            firmware_lower = device_info.firmware.lower()
-            if any(version in firmware_lower for version in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
-                return "mkii"  # MkII firmware range
-            elif any(version in firmware_lower for version in ["2.0", "2.1", "2.2", "2.3"]):
-                return "w_generation"
-        return "original"
 
 
 def is_legacy_device(device_info: DeviceInfo) -> bool:

--- a/pywiim/capabilities.py
+++ b/pywiim/capabilities.py
@@ -526,6 +526,11 @@ def detect_vendor(device_info: DeviceInfo) -> str:
     if "audio pro" in name_lower or "addon" in name_lower:
         return "audio_pro"
 
+    # Firmware-based fallback for Audio Pro devices with non-standard model strings
+    # (e.g. Link 2 model is "LINK 2 Wireless multiroom HiFi player" but firmware starts with "audiopro_")
+    if device_info.firmware and "audiopro" in device_info.firmware.lower():
+        return "audio_pro"
+
     return "linkplay_generic"
 
 
@@ -576,6 +581,13 @@ def detect_audio_pro_generation(device_info: DeviceInfo) -> str:
 
         return "mkii"  # Default to MkII for modern Audio Pro models
     else:
+        # For unrecognized Audio Pro models (e.g. Link 2), fall back to firmware version
+        if device_info.firmware:
+            firmware_lower = device_info.firmware.lower()
+            if any(version in firmware_lower for version in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
+                return "mkii"  # MkII firmware range
+            elif any(version in firmware_lower for version in ["2.0", "2.1", "2.2", "2.3"]):
+                return "w_generation"
         return "original"
 
 

--- a/pywiim/device_capabilities.py
+++ b/pywiim/device_capabilities.py
@@ -94,6 +94,19 @@ DEVICE_CAPABILITIES: dict[str, DeviceInputs] = {
         notes="Arylic/LinkPlay devices: plm_support is documented but may be incomplete. "
         "Common inputs: Line In, Optical, Bluetooth, USB.",
     ),
+    # Audio Pro Devices (confirmed physical inputs from device owners)
+    "link_2_wireless_multiroom_hifi_player": DeviceInputs(
+        inputs=["bluetooth", "optical", "coaxial", "rca"],
+        notes="Audio Pro Link 2: WiFi, Bluetooth, Optical In (TOSLINK), Coaxial In (S/PDIF), RCA analog in",
+    ),
+    "a28_speaker": DeviceInputs(
+        inputs=["bluetooth", "optical", "rca", "hdmi"],
+        notes="Audio Pro A28: WiFi, Bluetooth, Optical In, RCA/Line In, HDMI In",
+    ),
+    "addon_c5_mkii_speaker": DeviceInputs(
+        inputs=["bluetooth", "rca"],
+        notes="Audio Pro ADDON C5 MkII: WiFi, Bluetooth, RCA/Line In",
+    ),
     # Generic LinkPlay device (augment with common inputs)
     "linkplay_generic": DeviceInputs(
         inputs=["bluetooth", "line_in", "optical", "rca"],

--- a/pywiim/player/source_capabilities.py
+++ b/pywiim/player/source_capabilities.py
@@ -109,6 +109,7 @@ SOURCE_CAPABILITIES: dict[str, SourceCapability] = {
     "aux": SourceCapability.NONE,
     "hdmi": SourceCapability.NONE,
     "phono": SourceCapability.NONE,  # WiiM Ultra turntable input
+    "rca": SourceCapability.NONE,  # Audio Pro RCA line input (mode 44)
     "line_in_2": SourceCapability.NONE,
     "linein_2": SourceCapability.NONE,
 }

--- a/pywiim/player/statemgr.py
+++ b/pywiim/player/statemgr.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
+from ..api.constants import MODE_MAP
 from ..exceptions import WiiMTimeoutError
 from ..metadata import is_valid_metadata_value
 from ..polling import PollingStrategy
@@ -304,6 +305,10 @@ class StateManager:
             # Device info - only on full refresh or first time (not needed every poll)
             if full or self.player._device_info is None:
                 await self._refresh_device_info()
+                # If the full refresh just established a new profile that prefers UPnP for source,
+                # _refresh_core_status() ran before the profile was set and skipped
+                # GetControlDeviceInfo. Re-seed the source now that the profile is known.
+                await self._seed_source_after_profile()
 
             # Trigger-based fetching (skip for slaves - they get data from master)
             if not self.player.is_slave:
@@ -402,6 +407,7 @@ class StateManager:
         # during mode/source transitions. See: https://github.com/mjcumming/wiim/issues/157
         upnp_volume: int | None = None
         upnp_mute: bool | None = None
+        upnp_source: str | None = None
 
         if (
             self.player._upnp_client
@@ -424,6 +430,32 @@ class StateManager:
                     err,
                 )
 
+            # Poll source via GetControlDeviceInfo for devices that prefer UPnP for source
+            # (e.g. Audio Pro MkII: HTTP getStatusEx returns mode=0 when idle, masking actual input)
+            if (
+                self.player._profile is not None
+                and self.player._profile.state_sources.source == "upnp"
+            ):
+                try:
+                    info = await self.player._upnp_client.get_control_device_info()
+                    play_mode = info.get("PlayMode")
+                    if play_mode is not None:
+                        mapped = MODE_MAP.get(str(play_mode))
+                        if mapped and mapped not in ("unknown", "idle"):
+                            upnp_source = mapped
+                            _LOGGER.debug(
+                                "Got source from UPnP GetControlDeviceInfo for %s: PlayMode=%s -> %s",
+                                self.player.client.host,
+                                play_mode,
+                                upnp_source,
+                            )
+                except Exception as err:
+                    _LOGGER.debug(
+                        "UPnP GetControlDeviceInfo failed for %s: %s",
+                        self.player.client.host,
+                        err,
+                    )
+
         # Update StateSynchronizer with HTTP data
         status_dict = status.model_dump(exclude_none=False) if status else {}
         if "entity_picture" in status_dict:
@@ -432,11 +464,13 @@ class StateManager:
             if field_name not in status_dict:
                 status_dict[field_name] = None
 
-        # Override volume/mute with UPnP values if available (UPnP preferred)
+        # Override volume/mute/source with UPnP values if available (UPnP preferred)
         if upnp_volume is not None:
             status_dict["volume"] = upnp_volume
         if upnp_mute is not None:
             status_dict["muted"] = upnp_mute
+        if upnp_source is not None:
+            status_dict["source"] = upnp_source
 
         self.player._state_synchronizer.update_from_http(status_dict)
 
@@ -553,6 +587,42 @@ class StateManager:
         self.player._device_info = device_info
         # Update device profile when device_info changes
         self.player._update_profile_from_device_info()
+
+    async def _seed_source_after_profile(self) -> None:
+        """Seed source via GetControlDeviceInfo after profile is established on full refresh.
+
+        _refresh_core_status() runs before device info is fetched, so on the initial full
+        refresh the profile isn't set yet and GetControlDeviceInfo is skipped. This method
+        re-runs the source poll once the profile is known, so the source is correct
+        immediately after startup rather than waiting for the first incremental refresh.
+        """
+        if (
+            self.player._profile is None
+            or self.player._profile.state_sources.source != "upnp"
+            or not self.player._upnp_client
+            or not self.player._upnp_client.rendering_control
+        ):
+            return
+
+        try:
+            info = await self.player._upnp_client.get_control_device_info()
+            play_mode = info.get("PlayMode")
+            if play_mode is not None:
+                mapped = MODE_MAP.get(str(play_mode))
+                if mapped and mapped not in ("unknown", "idle"):
+                    self.player._state_synchronizer.update_from_http({"source": mapped})
+                    _LOGGER.debug(
+                        "Seeded source from GetControlDeviceInfo after profile set for %s: PlayMode=%s -> %s",
+                        self.player.client.host,
+                        play_mode,
+                        mapped,
+                    )
+        except Exception as err:
+            _LOGGER.debug(
+                "GetControlDeviceInfo source seed failed for %s: %s",
+                self.player.client.host,
+                err,
+            )
 
     async def _handle_triggers(self, status: PlayerStatus) -> None:
         """Handle trigger-based fetching (track change, source change, EQ change).

--- a/pywiim/player/statemgr.py
+++ b/pywiim/player/statemgr.py
@@ -431,17 +431,20 @@ class StateManager:
                 )
 
             # Poll source via GetControlDeviceInfo for devices that prefer UPnP for source
-            # (e.g. Audio Pro MkII: HTTP getStatusEx returns mode=0 when idle, masking actual input)
+            # (e.g. Audio Pro MkII: HTTP getStatusEx returns mode=0 when idle, masking actual input).
+            # Skip when HTTP already returned a valid streaming source to avoid an unnecessary round-trip.
+            http_source = status.source if status else None
             if (
                 self.player._profile is not None
                 and self.player._profile.state_sources.source == "upnp"
+                and http_source in (None, "idle")
             ):
                 try:
                     info = await self.player._upnp_client.get_control_device_info()
                     play_mode = info.get("PlayMode")
                     if play_mode is not None:
                         mapped = MODE_MAP.get(str(play_mode))
-                        if mapped and mapped not in ("unknown", "idle"):
+                        if mapped and mapped != "idle":
                             upnp_source = mapped
                             _LOGGER.debug(
                                 "Got source from UPnP GetControlDeviceInfo for %s: PlayMode=%s -> %s",
@@ -601,6 +604,7 @@ class StateManager:
             or self.player._profile.state_sources.source != "upnp"
             or not self.player._upnp_client
             or not self.player._upnp_client.rendering_control
+            or self.player.source not in (None, "idle")
         ):
             return
 
@@ -609,7 +613,7 @@ class StateManager:
             play_mode = info.get("PlayMode")
             if play_mode is not None:
                 mapped = MODE_MAP.get(str(play_mode))
-                if mapped and mapped not in ("unknown", "idle"):
+                if mapped and mapped != "idle":
                     self.player._state_synchronizer.update_from_http({"source": mapped})
                     _LOGGER.debug(
                         "Seeded source from GetControlDeviceInfo after profile set for %s: PlayMode=%s -> %s",

--- a/pywiim/profiles.py
+++ b/pywiim/profiles.py
@@ -29,10 +29,17 @@ Usage:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from .model_names import is_known_wiim_model
+from .normalize import normalize_vendor
+
+# Firmware version patterns for Audio Pro generation detection.
+# Use word-boundary–style lookarounds to avoid matching substrings like "420200" or "v1.205".
+_MKII_FIRMWARE_RE = r"(?<!\d)1\.5[6-9](?!\d)|(?<!\d)1\.60(?!\d)"
+_W_GEN_FIRMWARE_RE = r"(?<!\d)2\.[0-3](?!\d)"
 
 if TYPE_CHECKING:
     from .models import DeviceInfo
@@ -47,6 +54,8 @@ __all__ = [
     "GroupingConfig",
     "get_device_profile",
     "PROFILES",
+    "detect_vendor",
+    "detect_audio_pro_generation",
 ]
 
 
@@ -344,25 +353,18 @@ PROFILES: dict[str, DeviceProfile] = {
 # =============================================================================
 
 
-def _detect_vendor(device_info: DeviceInfo) -> str:
+def detect_vendor(device_info: DeviceInfo) -> str:
     """Detect device vendor from device information.
 
     Args:
         device_info: Device information
 
     Returns:
-        Vendor string: "wiim", "arylic", "audio_pro", or "linkplay_generic"
+        Normalized vendor string: "wiim", "arylic", "audio_pro", or "linkplay_generic"
     """
     if not device_info.model:
-        # Try device name as fallback
         if device_info.name:
-            name_lower = device_info.name.lower()
-            if "wiim" in name_lower:
-                return "wiim"
-            if "arylic" in name_lower or "up2stream" in name_lower:
-                return "arylic"
-            if "audio pro" in name_lower or "addon" in name_lower:
-                return "audio_pro"
+            return normalize_vendor(device_info.name)
         return "linkplay_generic"
 
     model_lower = device_info.model.lower()
@@ -394,8 +396,8 @@ def _detect_vendor(device_info: DeviceInfo) -> str:
     return "linkplay_generic"
 
 
-def _detect_audio_pro_generation(device_info: DeviceInfo) -> str:
-    """Detect Audio Pro device generation.
+def detect_audio_pro_generation(device_info: DeviceInfo) -> str:
+    """Detect Audio Pro device generation for optimized handling.
 
     Args:
         device_info: Device information
@@ -408,37 +410,30 @@ def _detect_audio_pro_generation(device_info: DeviceInfo) -> str:
 
     model_lower = device_info.model.lower()
 
-    # MkII detection
     if any(gen in model_lower for gen in ["mkii", "mk2", "mk ii", "mark ii"]):
         return "mkii"
-
-    # W-Generation detection
     if any(gen in model_lower for gen in ["w-", "w series", "w generation", "w gen"]):
         return "w_generation"
 
-    # For generic Audio Pro models, try to determine from firmware
+    # For known Audio Pro model strings, try firmware to distinguish MkII from W-gen
     if any(model in model_lower for model in ["a10", "a15", "a28", "c10", "audio pro"]):
         if device_info.firmware:
             firmware_lower = device_info.firmware.lower()
-            # MkII firmware versions
-            if any(v in firmware_lower for v in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
+            if re.search(_MKII_FIRMWARE_RE, firmware_lower):
                 return "mkii"
-            # W-generation firmware versions
-            if any(v in firmware_lower for v in ["2.0", "2.1", "2.2", "2.3"]):
+            if re.search(_W_GEN_FIRMWARE_RE, firmware_lower):
                 return "w_generation"
-        # Default modern Audio Pro to MkII (most likely)
-        return "mkii"
+        return "mkii"  # Default to MkII for modern Audio Pro models
 
     # Firmware-based fallback for Audio Pro devices with non-standard model strings
     # (e.g. Link 2: firmware "audiopro_link2-user 1.56..." → MkII)
     if device_info.firmware:
         firmware_lower = device_info.firmware.lower()
-        if any(v in firmware_lower for v in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
+        if re.search(_MKII_FIRMWARE_RE, firmware_lower):
             return "mkii"
-        if any(v in firmware_lower for v in ["2.0", "2.1", "2.2", "2.3"]):
+        if re.search(_W_GEN_FIRMWARE_RE, firmware_lower):
             return "w_generation"
 
-    # Older models or unknown
     return "original"
 
 
@@ -487,11 +482,11 @@ def get_device_profile(device_info: DeviceInfo) -> DeviceProfile:
     Returns:
         DeviceProfile for this device type
     """
-    vendor = _detect_vendor(device_info)
+    vendor = detect_vendor(device_info)
 
     # Audio Pro has multiple generations with different profiles
     if vendor == "audio_pro":
-        generation = _detect_audio_pro_generation(device_info)
+        generation = detect_audio_pro_generation(device_info)
         profile_key = f"audio_pro_{generation}"
 
         if profile_key in PROFILES:

--- a/pywiim/profiles.py
+++ b/pywiim/profiles.py
@@ -232,8 +232,9 @@ PROFILE_AUDIO_PRO_MKII = DeviceProfile(
         # Position/duration can come from either, prefer UPnP for real-time
         position="upnp",
         duration="upnp",
-        # Metadata and source are fine from HTTP
-        source="http",
+        # Source: prefer UPnP (PlaybackStorageMedium events are reliable on MkII)
+        # HTTP mode returns 0 (idle) when nothing is playing, masking the actual input
+        source="upnp",
         title="http",
         artist="http",
         album="http",
@@ -385,6 +386,11 @@ def _detect_vendor(device_info: DeviceInfo) -> str:
     if "audio pro" in name_lower or "addon" in name_lower:
         return "audio_pro"
 
+    # Firmware-based fallback for Audio Pro devices with non-standard model strings
+    # (e.g. Link 2 model is "LINK 2 Wireless multiroom HiFi player" but firmware starts with "audiopro_")
+    if device_info.firmware and "audiopro" in device_info.firmware.lower():
+        return "audio_pro"
+
     return "linkplay_generic"
 
 
@@ -422,6 +428,15 @@ def _detect_audio_pro_generation(device_info: DeviceInfo) -> str:
                 return "w_generation"
         # Default modern Audio Pro to MkII (most likely)
         return "mkii"
+
+    # Firmware-based fallback for Audio Pro devices with non-standard model strings
+    # (e.g. Link 2: firmware "audiopro_link2-user 1.56..." → MkII)
+    if device_info.firmware:
+        firmware_lower = device_info.firmware.lower()
+        if any(v in firmware_lower for v in ["1.56", "1.57", "1.58", "1.59", "1.60"]):
+            return "mkii"
+        if any(v in firmware_lower for v in ["2.0", "2.1", "2.2", "2.3"]):
+            return "w_generation"
 
     # Older models or unknown
     return "original"

--- a/pywiim/upnp/client.py
+++ b/pywiim/upnp/client.py
@@ -843,6 +843,38 @@ class UpnpClient:
             _LOGGER.warning("GetMute failed for %s: %s", self.host, err)
             raise UpnpError(f"GetMute failed: {err}") from err
 
+    async def get_control_device_info(self) -> dict[str, Any]:
+        """Fetch current device state via GetControlDeviceInfo UPnP action.
+
+        This action is specific to LinkPlay/Audio Pro firmware and returns full
+        device state including PlayMode (current input source), volume, and mute,
+        even when the device is idle. Useful for Audio Pro devices where the HTTP
+        API does not reliably report the current input mode when idle.
+
+        Returns:
+            Dictionary with raw response fields, e.g.:
+            - PlayMode: current input mode (int string, maps via MODE_MAP)
+            - CurrentVolume: current volume level
+            - CurrentMute: current mute state
+
+        Raises:
+            UpnpError: If RenderingControl service is not available or action fails
+        """
+        if not self._rendering_control_service:
+            raise UpnpError("RenderingControl service not available")
+
+        try:
+            result = await self.async_call_action(
+                "rendering_control",
+                "GetControlDeviceInfo",
+                {"InstanceID": 0},
+            )
+            _LOGGER.debug("GetControlDeviceInfo result for %s: %s", self.host, result)
+            return result
+        except Exception as err:
+            _LOGGER.debug("GetControlDeviceInfo failed for %s: %s", self.host, err)
+            raise UpnpError(f"GetControlDeviceInfo failed: {err}") from err
+
     async def get_device_capabilities(self) -> dict[str, Any]:
         """Fetch device capabilities via GetDeviceCapabilities UPnP action.
 

--- a/pywiim/upnp/eventer.py
+++ b/pywiim/upnp/eventer.py
@@ -31,6 +31,19 @@ from .client import UpnpClient
 
 _LOGGER = logging.getLogger(__name__)
 
+# Maps UPnP AVTransport PlaybackStorageMedium values to pywiim source names.
+# Only physical inputs are listed; network sources (SONGLIST-NETWORK, etc.) are
+# left unmapped so HTTP polling continues to own them.
+_PLAYBACK_STORAGE_MEDIUM_MAP: dict[str, str] = {
+    "RCA": "rca",
+    "BLUETOOTH": "bluetooth",
+    "LINE-IN": "line_in",
+    "LINEIN": "line_in",
+    "OPTICAL": "optical",
+    "COAXIAL": "coaxial",
+    "HDMI": "hdmi",
+}
+
 
 def _is_valid_url(url: str | None) -> bool:
     """Validate that a string is a valid HTTP/HTTPS URL.
@@ -397,6 +410,16 @@ class UpnpEventer:
             if "TrackSource" in variables_dict:
                 changes["source"] = variables_dict["TrackSource"]
 
+            # Fallback: use PlaybackStorageMedium when TrackSource is absent or empty.
+            # Physical inputs (RCA, BLUETOOTH, etc.) set PlaybackStorageMedium but leave
+            # TrackSource blank, so this is the only UPnP signal available for them.
+            if not changes.get("source") and "PlaybackStorageMedium" in variables_dict:
+                medium = str(variables_dict["PlaybackStorageMedium"]).upper()
+                mapped = _PLAYBACK_STORAGE_MEDIUM_MAP.get(medium)
+                if mapped:
+                    changes["source"] = mapped
+                    _LOGGER.debug("Source from PlaybackStorageMedium: %s -> %s", medium, mapped)
+
         # Apply diff to state (same as original)
         if changes:
             self.state_manager.apply_diff(changes)
@@ -455,6 +478,7 @@ class UpnpEventer:
 
                 # Parse AVTransport service variables
                 if service_type == "AVTransport":
+                    playback_storage_medium: str | None = None
                     for var in list(instance):
                         # Strip namespace from tag name (e.g., {urn:...}TransportState -> TransportState)
                         var_name = var.tag.split("}")[-1] if "}" in var.tag else var.tag
@@ -504,11 +528,24 @@ class UpnpEventer:
                             changes.update(metadata_changes)
                         elif var_name == "TrackSource":
                             changes["source"] = var_value
+                        elif var_name == "PlaybackStorageMedium":
+                            playback_storage_medium = var_value
                         elif var_name in ("AVTransportURI", "CurrentURI"):
                             # Extract stream URL for potential ICY metadata extraction
                             # Store in changes but don't expose as a property (internal use)
                             changes["_stream_uri"] = var_value
                             _LOGGER.debug("Extracted stream URI from UPnP: %s", var_value[:100] if var_value else None)
+
+                    # Fallback: use PlaybackStorageMedium when TrackSource is absent or empty.
+                    if not changes.get("source") and playback_storage_medium:
+                        mapped = _PLAYBACK_STORAGE_MEDIUM_MAP.get(playback_storage_medium.upper())
+                        if mapped:
+                            changes["source"] = mapped
+                            _LOGGER.debug(
+                                "Source from PlaybackStorageMedium (LastChange): %s -> %s",
+                                playback_storage_medium,
+                                mapped,
+                            )
 
                 # Parse RenderingControl service variables
                 elif service_type == "RenderingControl":

--- a/tests/integration/test_audio_pro.py
+++ b/tests/integration/test_audio_pro.py
@@ -1,0 +1,165 @@
+"""Integration tests for Audio Pro device support.
+
+Tests vendor/generation detection, UPnP GetControlDeviceInfo, and source detection
+for Audio Pro devices with non-standard model strings (e.g. Link 2).
+
+Audio Pro devices use mTLS on port 4443 by default. The library auto-negotiates this.
+
+Run with:
+    WIIM_TEST_DEVICE=<ip> WIIM_TEST_PORT=4443 pytest tests/integration/test_audio_pro.py -v -m integration -s
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+AUDIO_PRO_IP = os.getenv("WIIM_TEST_DEVICE", "")
+AUDIO_PRO_PORT = int(os.getenv("WIIM_TEST_PORT", "4443"))
+
+if not AUDIO_PRO_IP:
+    pytest.skip("Set WIIM_TEST_DEVICE to an Audio Pro device IP to run these tests", allow_module_level=True)
+
+
+@pytest.fixture
+async def audio_pro_client():
+    """WiiMClient connected to the Audio Pro device."""
+    from pywiim.client import WiiMClient
+
+    client = WiiMClient(AUDIO_PRO_IP, port=AUDIO_PRO_PORT)
+    yield client
+    await client.close()
+
+
+@pytest.fixture
+async def audio_pro_player(audio_pro_client):
+    """Player instance connected to the Audio Pro device."""
+    from pywiim.player import Player
+
+    player = Player(audio_pro_client)
+    await player.refresh(full=True)
+    yield player
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestAudioProCapabilityDetection:
+    """Verify vendor/generation detection for non-standard Audio Pro model strings."""
+
+    async def test_vendor_detected_as_audio_pro(self, audio_pro_client):
+        """Device must be detected as audio_pro, not linkplay_generic."""
+        from pywiim.capabilities import detect_vendor
+
+        device_info = await audio_pro_client.get_device_info_model()
+        print(f"\n  model={device_info.model!r}  firmware={device_info.firmware!r}")
+
+        vendor = detect_vendor(device_info)
+        assert vendor == "audio_pro", (
+            f"Expected audio_pro but got {vendor!r}. "
+            f"model={device_info.model!r}, firmware={device_info.firmware!r}"
+        )
+
+    async def test_generation_detected_as_mkii(self, audio_pro_client):
+        """MkII firmware must map to mkii generation."""
+        from pywiim.capabilities import detect_audio_pro_generation
+
+        device_info = await audio_pro_client.get_device_info_model()
+        generation = detect_audio_pro_generation(device_info)
+        print(f"\n  generation={generation!r}")
+
+        assert generation == "mkii", (
+            f"Expected mkii but got {generation!r}. "
+            f"firmware={device_info.firmware!r}"
+        )
+
+    async def test_profile_is_audio_pro_mkii(self, audio_pro_player):
+        """Player profile must be audio_pro_mkii after initialization."""
+        player = audio_pro_player
+        profile = player._profile
+        assert profile is not None, "Player has no profile set"
+        assert profile.vendor == "audio_pro", f"Profile vendor: {profile.vendor!r}"
+        assert profile.generation == "mkii", f"Profile generation: {profile.generation!r}"
+        print(f"\n  profile.vendor={profile.vendor!r}  profile.generation={profile.generation!r}")
+
+    async def test_profile_source_is_upnp(self, audio_pro_player):
+        """MkII profile must prefer UPnP for source (HTTP returns mode=0 when idle)."""
+        player = audio_pro_player
+        assert player._profile is not None
+        assert player._profile.state_sources.source == "upnp", (
+            f"Expected source='upnp', got {player._profile.state_sources.source!r}"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestAudioProUPnPGetControlDeviceInfo:
+    """Verify GetControlDeviceInfo returns valid PlayMode for source detection."""
+
+    async def test_get_control_device_info_returns_play_mode(self, audio_pro_client):
+        """GetControlDeviceInfo must return a PlayMode field."""
+        from pywiim.upnp.client import UpnpClient
+
+        description_url = f"http://{AUDIO_PRO_IP}:49152/description.xml"
+        upnp_client = await UpnpClient.create(AUDIO_PRO_IP, description_url)
+        try:
+            result = await upnp_client.get_control_device_info()
+            print(f"\n  GetControlDeviceInfo result: {result}")
+            assert "PlayMode" in result, f"PlayMode not in result: {result}"
+        finally:
+            await upnp_client.close()
+
+    async def test_get_control_device_info_play_mode_maps_to_source(self, audio_pro_client):
+        """PlayMode returned by GetControlDeviceInfo must map to a known source string."""
+        from pywiim.api.constants import MODE_MAP
+        from pywiim.upnp.client import UpnpClient
+
+        description_url = f"http://{AUDIO_PRO_IP}:49152/description.xml"
+        upnp_client = await UpnpClient.create(AUDIO_PRO_IP, description_url)
+        try:
+            result = await upnp_client.get_control_device_info()
+            play_mode = str(result.get("PlayMode", ""))
+            print(f"\n  PlayMode={play_mode!r}")
+            if play_mode:
+                mapped = MODE_MAP.get(play_mode)
+                print(f"  mapped source={mapped!r}")
+                assert mapped is not None, (
+                    f"PlayMode {play_mode!r} not in MODE_MAP. "
+                    f"Need to add it to pywiim/api/constants.py"
+                )
+        finally:
+            await upnp_client.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestAudioProSourceDetection:
+    """Verify source is correctly reported after refresh."""
+
+    async def test_source_is_not_unknown_after_refresh(self, audio_pro_player):
+        """After a refresh, source must not be unknown.
+
+        Requires the device to have an active input selected (not in standby).
+        """
+        player = audio_pro_player
+        source = player.source
+        print(f"\n  source={source!r}")
+        if source is None:
+            pytest.skip("Device is in standby (source=None); switch to an input and retry")
+        assert source != "unknown", f"source='unknown' means mode mapping failed: {source!r}"
+
+    async def test_rca_source_detected_via_get_control_device_info(self, audio_pro_player):
+        """When device is set to RCA input, refresh must report source='rca'.
+
+        Prerequisite: switch the device to RCA input before running this test.
+        """
+        player = audio_pro_player
+        await player.refresh()
+        source = player.source
+        print(f"\n  source after refresh={source!r}")
+        if source is None:
+            pytest.skip("Device is in standby; switch to RCA input and retry")
+        assert source == "rca", (
+            f"Expected source='rca' (RCA input), got {source!r}. "
+            "Make sure the device is set to RCA input."
+        )

--- a/tests/unit/player/test_source_capabilities.py
+++ b/tests/unit/player/test_source_capabilities.py
@@ -71,7 +71,7 @@ class TestSourceCapabilitiesMapping:
 
     def test_physical_inputs_have_no_control(self):
         """Test physical inputs have no control."""
-        physical = ["line_in", "linein", "optical", "coaxial", "coax", "aux", "hdmi", "phono"]
+        physical = ["line_in", "linein", "optical", "coaxial", "coax", "aux", "hdmi", "phono", "rca"]
         for source in physical:
             caps = SOURCE_CAPABILITIES[source]
             assert caps == SourceCapability.NONE, f"{source} should have NONE"

--- a/tests/unit/player/test_statemgr.py
+++ b/tests/unit/player/test_statemgr.py
@@ -609,3 +609,80 @@ class TestStateManager:
 
         called_payload = mock_player._state_synchronizer.update_from_upnp.call_args[0][0]
         assert called_payload == {"volume": 0.5, "muted": True}
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_get_control_device_info_for_upnp_source_profile(
+        self, state_manager, mock_player
+    ):
+        """When profile.state_sources.source == 'upnp', refresh polls GetControlDeviceInfo.
+
+        The resulting PlayMode is mapped via MODE_MAP and injected into the HTTP status dict
+        before calling update_from_http, so the source shows up correctly even when the
+        HTTP API returns mode=0 (idle).
+        """
+        mock_status = PlayerStatus(play_state="play", volume=50)
+        mock_player.client.get_player_status_model = AsyncMock(return_value=mock_status)
+        TestStateManager._setup_refresh_mocks(mock_player, state_manager)
+
+        # Set up UPnP client with get_control_device_info returning PlayMode=44 (rca)
+        mock_upnp_client = MagicMock()
+        mock_upnp_client.get_volume = AsyncMock(return_value=50)
+        mock_upnp_client.get_mute = AsyncMock(return_value=False)
+        mock_upnp_client.get_control_device_info = AsyncMock(return_value={"PlayMode": "44"})
+        mock_player._upnp_client = mock_upnp_client
+
+        # Set profile with source="upnp"
+        mock_profile = MagicMock()
+        mock_profile.state_sources.source = "upnp"
+        mock_profile.state_sources.volume = "upnp"
+        mock_profile.state_sources.mute = "upnp"
+        mock_player._profile = mock_profile
+
+        mock_player._device_info = DeviceInfo(uuid="test-uuid", name="Turntable")
+
+        with patch.object(mock_player._group_ops, "propagate_metadata_to_slaves", new_callable=MagicMock):
+            await state_manager.refresh(full=False)
+
+        mock_upnp_client.get_control_device_info.assert_called_once()
+        call_kwargs = mock_player._state_synchronizer.update_from_http.call_args[0][0]
+        assert call_kwargs.get("source") == "rca"
+
+    @pytest.mark.asyncio
+    async def test_seed_source_after_profile_on_full_refresh(
+        self, state_manager, mock_player
+    ):
+        """On full refresh, _seed_source_after_profile runs after device info is fetched.
+
+        _refresh_core_status() runs before the profile is set, so GetControlDeviceInfo
+        is skipped there. _seed_source_after_profile() re-polls after the profile is
+        known so the source is seeded immediately on startup.
+        """
+        mock_status = PlayerStatus(play_state="play", volume=50)
+        mock_info = DeviceInfo(uuid="test-uuid", name="Turntable")
+        mock_player.client.get_player_status_model = AsyncMock(return_value=mock_status)
+        mock_player.client.get_device_info_model = AsyncMock(return_value=mock_info)
+        TestStateManager._setup_refresh_mocks(mock_player, state_manager)
+
+        # UPnP client ready
+        mock_upnp_client = MagicMock()
+        mock_upnp_client.get_volume = AsyncMock(return_value=50)
+        mock_upnp_client.get_mute = AsyncMock(return_value=False)
+        mock_upnp_client.get_control_device_info = AsyncMock(return_value={"PlayMode": "44"})
+        mock_player._upnp_client = mock_upnp_client
+
+        # Profile is set BEFORE full refresh (simulating what _refresh_device_info does)
+        mock_profile = MagicMock()
+        mock_profile.state_sources.source = "upnp"
+        mock_profile.state_sources.volume = "upnp"
+        mock_profile.state_sources.mute = "upnp"
+        mock_player._profile = mock_profile
+
+        with patch.object(mock_player._group_ops, "propagate_metadata_to_slaves", new_callable=MagicMock):
+            await state_manager.refresh(full=True)
+
+        # _seed_source_after_profile should have called GetControlDeviceInfo
+        assert mock_upnp_client.get_control_device_info.call_count >= 1
+        # And update_from_http should have been called with source='rca' at some point
+        calls = mock_player._state_synchronizer.update_from_http.call_args_list
+        sources = [c[0][0].get("source") for c in calls if "source" in c[0][0]]
+        assert "rca" in sources, f"Expected 'rca' in source calls: {sources}"

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -161,6 +161,36 @@ class TestAudioProGenerationDetection:
         # Unknown models return "original" as fallback
         assert generation == "original"
 
+    def test_detect_audio_pro_generation_link2_firmware_fallback(self):
+        """Link 2 with audiopro firmware 1.56 → MkII via firmware version fallback."""
+        device_info = DeviceInfo(
+            uuid="test",
+            model="LINK 2 Wireless multiroom HiFi player",
+            firmware="audiopro_link2-user 1.56",
+        )
+        generation = detect_audio_pro_generation(device_info)
+        assert generation == "mkii"
+
+
+class TestVendorFirmwareFallback:
+    """Test vendor detection via firmware string for non-standard model names."""
+
+    def test_detect_vendor_link2_firmware_fallback(self):
+        """Link 2 model string doesn't match keywords → firmware 'audiopro_...' → audio_pro."""
+        device_info = DeviceInfo(
+            uuid="test",
+            model="LINK 2 Wireless multiroom HiFi player",
+            firmware="audiopro_link2-user 1.56",
+        )
+        vendor = detect_vendor(device_info)
+        assert vendor == "audio_pro"
+
+    def test_detect_vendor_no_firmware_fallback(self):
+        """Unknown model with no firmware → linkplay_generic (no firmware to check)."""
+        device_info = DeviceInfo(uuid="test", model="Some Unknown Speaker")
+        vendor = detect_vendor(device_info)
+        assert vendor == "linkplay_generic"
+
 
 class TestLEDControlDetection:
     """Test LED control format detection."""

--- a/tests/unit/test_device_capabilities.py
+++ b/tests/unit/test_device_capabilities.py
@@ -1,0 +1,37 @@
+"""Unit tests for device capability database (physical input lists)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pywiim.device_capabilities import get_device_inputs
+
+
+class TestAudioProDeviceInputs:
+    """Test device input lookups for Audio Pro models."""
+
+    def test_link2_inputs(self):
+        """Link 2 has optical, coaxial, RCA, and bluetooth inputs."""
+        result = get_device_inputs("LINK 2 Wireless multiroom HiFi player")
+        assert result is not None
+        assert "rca" in result.inputs
+        assert "optical" in result.inputs
+        assert "coaxial" in result.inputs
+        assert "bluetooth" in result.inputs
+
+    def test_a28_inputs(self):
+        """A28 has optical, RCA, HDMI, and bluetooth inputs."""
+        result = get_device_inputs("A28 Speaker")
+        assert result is not None
+        assert "optical" in result.inputs
+        assert "rca" in result.inputs
+        assert "hdmi" in result.inputs
+        assert "bluetooth" in result.inputs
+
+    def test_c5_mkii_inputs(self):
+        """ADDON C5 MkII has RCA and bluetooth inputs only."""
+        result = get_device_inputs("ADDON C5 MkII Speaker")
+        assert result is not None
+        assert "rca" in result.inputs
+        assert "bluetooth" in result.inputs
+        assert "optical" not in result.inputs

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -372,3 +372,24 @@ class TestProfileIntegration:
         assert mkii_profile.endpoints.supports_getMetaInfo is False
         # WiiM does
         assert wiim_profile.endpoints.supports_getMetaInfo is True
+
+
+class TestLink2FirmwareFallback:
+    """Test that Link 2 with non-standard model string gets the correct MkII profile."""
+
+    def test_link2_gets_mkii_profile(self):
+        """Link 2 model + audiopro firmware → audio_pro vendor, mkii generation."""
+        device_info = DeviceInfo(
+            uuid="FF98F08F07C5B3572C4FB7E1",
+            name="Turntable",
+            model="LINK 2 Wireless multiroom HiFi player",
+            firmware="audiopro_link2-user 1.56",
+        )
+        profile = get_device_profile(device_info)
+        assert profile.vendor == "audio_pro"
+        assert profile.generation == "mkii"
+
+    def test_mkii_profile_source_is_upnp(self):
+        """MkII profile must prefer UPnP for source (HTTP returns mode=0 when idle)."""
+        profile = PROFILES["audio_pro_mkii"]
+        assert profile.state_sources.source == "upnp"

--- a/tests/unit/upnp/test_client.py
+++ b/tests/unit/upnp/test_client.py
@@ -677,3 +677,39 @@ class TestUpnpClient:
         assert "volume" in snapshot
         assert "muted" in snapshot
         assert "available_actions" in snapshot
+
+
+class TestGetControlDeviceInfo:
+    """Tests for UpnpClient.get_control_device_info (Audio Pro-specific action)."""
+
+    @pytest.mark.asyncio
+    async def test_get_control_device_info_success(self):
+        """Returns parsed result dict when RenderingControl service is available."""
+        from pywiim.upnp.client import UpnpClient
+
+        client = UpnpClient("192.168.1.200", "https://192.168.1.200/description.xml", None)
+        client._rendering_control_service = MagicMock()
+        client.async_call_action = AsyncMock(return_value={"PlayMode": "44", "CurrentVolume": "50"})
+
+        result = await client.get_control_device_info()
+
+        client.async_call_action.assert_called_once_with(
+            "rendering_control",
+            "GetControlDeviceInfo",
+            {"InstanceID": 0},
+        )
+        assert result["PlayMode"] == "44"
+        assert result["CurrentVolume"] == "50"
+
+    @pytest.mark.asyncio
+    async def test_get_control_device_info_no_service(self):
+        """Raises UpnpError when RenderingControl service is not available."""
+        from async_upnp_client.exceptions import UpnpError
+
+        from pywiim.upnp.client import UpnpClient
+
+        client = UpnpClient("192.168.1.200", "https://192.168.1.200/description.xml", None)
+        client._rendering_control_service = None
+
+        with pytest.raises(UpnpError, match="RenderingControl service not available"):
+            await client.get_control_device_info()

--- a/tests/unit/upnp/test_eventer.py
+++ b/tests/unit/upnp/test_eventer.py
@@ -586,3 +586,74 @@ class TestUpnpEventer:
         # Should update source
         call_args = mock_state_manager.apply_diff.call_args[0][0]
         assert call_args["source"] == "spotify"
+
+
+class TestPlaybackStorageMedium:
+    """Test PlaybackStorageMedium fallback for physical inputs (RCA, Bluetooth, etc.)."""
+
+    def _make_eventer(self):
+        mock_upnp_client = MagicMock()
+        mock_upnp_client.host = "192.168.1.200"
+        mock_state_manager = MagicMock()
+        mock_state_manager.apply_diff = MagicMock()
+        mock_state_manager.play_state = None
+        return UpnpEventer(mock_upnp_client, mock_state_manager, "test-uuid"), mock_state_manager
+
+    def _make_service(self):
+        mock_service = MagicMock()
+        mock_service.service_id = "AVTransport"
+        return mock_service
+
+    def _make_var(self, name, value):
+        var = MagicMock()
+        var.name = name
+        var.value = value
+        return var
+
+    def test_source_from_playback_storage_medium_rca(self):
+        """PlaybackStorageMedium=RCA sets source=rca when TrackSource is absent."""
+        eventer, state_manager = self._make_eventer()
+        eventer._on_event(
+            self._make_service(),
+            [self._make_var("PlaybackStorageMedium", "RCA")],
+        )
+        call_args = state_manager.apply_diff.call_args[0][0]
+        assert call_args["source"] == "rca"
+
+    def test_source_from_playback_storage_medium_bluetooth(self):
+        """PlaybackStorageMedium=BLUETOOTH sets source=bluetooth when TrackSource is absent."""
+        eventer, state_manager = self._make_eventer()
+        eventer._on_event(
+            self._make_service(),
+            [self._make_var("PlaybackStorageMedium", "BLUETOOTH")],
+        )
+        call_args = state_manager.apply_diff.call_args[0][0]
+        assert call_args["source"] == "bluetooth"
+
+    def test_playback_storage_medium_ignored_when_track_source_present(self):
+        """TrackSource takes priority over PlaybackStorageMedium."""
+        eventer, state_manager = self._make_eventer()
+        eventer._on_event(
+            self._make_service(),
+            [
+                self._make_var("TrackSource", "spotify"),
+                self._make_var("PlaybackStorageMedium", "RCA"),
+            ],
+        )
+        call_args = state_manager.apply_diff.call_args[0][0]
+        assert call_args["source"] == "spotify"
+
+    def test_parse_last_change_playback_storage_medium(self):
+        """PlaybackStorageMedium in LastChange XML sets source when TrackSource is absent."""
+        eventer, state_manager = self._make_eventer()
+        last_change_xml = """<Event xmlns="urn:schemas-upnp-org:metadata-1-0/AVT/">
+            <InstanceID val="0">
+                <PlaybackStorageMedium val="OPTICAL"/>
+            </InstanceID>
+        </Event>"""
+        eventer._on_event(
+            self._make_service(),
+            [self._make_var("LastChange", last_change_xml)],
+        )
+        call_args = state_manager.apply_diff.call_args[0][0]
+        assert call_args["source"] == "optical"


### PR DESCRIPTION
## Summary

Audio Pro devices with non-standard model strings (e.g. the Link 2, whose model string is `"LINK 2 Wireless multiroom HiFi player"`) were misidentified as `linkplay_generic`, got the wrong profile (Audio Pro Original, HTTP-only), and always showed `source=unknown` because HTTP `getStatusEx` returns `mode=0` when idle.

This PR fixes source detection end-to-end, tested against real Audio Pro hardware (Link 2, A28, ADDON C5 MkII).

### Commit 1 — Add RCA input support for Audio Pro devices
- `MODE_MAP`: mode `44` → `"rca"` (confirmed via tcpdump on Link 2 when RCA input selected)
- `SOURCE_CAPABILITIES`: `"rca"` with `SourceCapability.NONE` (physical input, no transport controls)
- `eventer.py`: `_PLAYBACK_STORAGE_MEDIUM_MAP` maps UPnP AVTransport `PlaybackStorageMedium` values (`RCA`, `BLUETOOTH`, `LINE-IN`, `OPTICAL`, `COAXIAL`, `HDMI`) to pywiim source names as fallback when `TrackSource` is blank — physical inputs leave `TrackSource` empty

### Commit 2 — Fix Audio Pro source detection for non-standard model strings (Link 2)
- **Vendor/generation detection fallback**: if model keyword matching fails, check firmware — `"audiopro_"` prefix → `vendor=audio_pro`; firmware version `1.56–1.60` → `generation=mkii` (applied in both `capabilities.py` and `profiles.py`)
- **`PROFILE_AUDIO_PRO_MKII`**: `state_sources.source` changed from `"http"` to `"upnp"` — HTTP returns `mode=0` when idle, masking the actual input
- **`UpnpClient.get_control_device_info()`**: new method calling `RenderingControl:GetControlDeviceInfo`, which returns `PlayMode` even when the device is idle
- **`statemgr.py`**: when `profile.state_sources.source == "upnp"`, poll `get_control_device_info()` each refresh cycle and inject source into status; `_seed_source_after_profile()` re-polls after the initial device info fetch so source is correct on the first full refresh

### Commit 3 — Add device capability database entries for known Audio Pro models
Without these, all three Audio Pro devices fell through to `linkplay_generic`, which trusts the unreliable `plm_support` bitmask. Adds confirmed physical inputs for:
- **Link 2**: Bluetooth, Optical (TOSLINK), Coaxial (S/PDIF), RCA
- **A28**: Bluetooth, Optical, RCA/Line In, HDMI
- **ADDON C5 MkII**: Bluetooth, RCA/Line In

## Test plan

- [ ] 15 new unit tests across `test_eventer.py`, `test_capabilities.py`, `test_profiles.py`, `test_client.py`, `test_statemgr.py`, `test_device_capabilities.py` — all pass (`pytest tests/unit/`)
- [ ] Integration tests in `tests/integration/test_audio_pro.py` — run with `WIIM_TEST_DEVICE=<audio-pro-ip> WIIM_TEST_PORT=4443 pytest tests/integration/test_audio_pro.py -v -m integration -s`
- [ ] Source correctly reported on full refresh (not just subsequent polls) — verified on real hardware

---

Happy to answer any questions or make changes — if anything looks off or could fit better with the project conventions, just let me know!