### PR TITLE
[codex] Add read-only WiiM API probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **More read-only WiiM daily-use APIs** — `WiiMClient` now exposes
+  `get_audio_input_capability()` for the firmware-spelled `getAudioInputCapbility`,
+  read-only LV2 graphic EQ helpers (`get_graphic_eq_bands()`,
+  `get_graphic_eq_preset_list()` for `Eq10HP`), and read-only room-correction
+  state (`get_room_correction()`). These APIs are documented as daily-use or
+  capability/diagnostic surfaces; one-off setup, account, network, and token
+  endpoints remain intentionally out of scope. Diagnostics and verify CLIs now
+  include these read-only probes/summaries.
+
 ## [2.2.18] - 2026-06-27
 
 ### Added

--- a/docs/design/WIIM_DISCOVERED_APIS.md
+++ b/docs/design/WIIM_DISCOVERED_APIS.md
@@ -13,6 +13,7 @@ payloads have been tested across real devices and firmware versions.
 | Command | pywiim helper | Model | Current use |
 | --- | --- | --- | --- |
 | `getAudioInputEnable` | `client.get_audio_input_enable()` | `AudioInputEnable` | Read-only input enable metadata |
+| `getAudioInputCapbility` | `client.get_audio_input_capability()` | `AudioInputCapability` | Read-only input capability metadata |
 | `getModeRename` | `client.get_mode_rename()` | `dict[str, str]` | Read-only user source-label map |
 | `GetAcousticCapability` | `client.get_acoustic_capability()` | `AcousticCapability` | Read-only acoustic capability blocks |
 | `getAllRoutines` | `client.get_all_routines()` | `RoutineList` | Read-only routine list |
@@ -43,6 +44,29 @@ Example shape:
 Possible later use: enrich `source_catalog` with per-device input enablement.
 This should be an overlay on stable source IDs and profile/hardware knowledge,
 not a replacement for source identity.
+
+## `getAudioInputCapbility`
+
+The firmware command is misspelled as `Capbility`. It returns available input
+modes without the enable/disable state from `getAudioInputEnable`.
+
+Example shape:
+
+```json
+{
+  "ver": "1.0",
+  "audioInput": [
+    {"mode": "wifi"},
+    {"mode": "line-in"},
+    {"mode": "bluetooth"},
+    {"mode": "optical"}
+  ]
+}
+```
+
+Possible later use: fallback or enrichment source for `source_catalog` when
+`InputList` is absent. Treat modes as raw device labels and normalize through
+pywiim's existing source normalization before any user-facing behavior.
 
 ## `getModeRename`
 
@@ -150,6 +174,30 @@ Possible later use: enrich audio-output availability, especially USB DAC
 presence and capability metadata. Do not replace the existing output probe
 strategy until this endpoint is tested on multiple WiiM models and firmware
 versions.
+
+## Related daily-use APIs
+
+The same app-string sweep exposed a few endpoints that are closer to daily
+listening than one-time setup:
+
+| Command | pywiim helper | Model | Current use |
+| --- | --- | --- | --- |
+| `EQGetLV2Band:http://moddevices.com/plugins/caps/Eq10HP` | `client.get_graphic_eq_bands()` | `GraphicEQSettings` | Read-only graphic EQ state |
+| `EQGetLV2SourceBandEx:{...Eq10HP...}` | `client.get_graphic_eq_bands(source_name=...)` | `GraphicEQSettings` | Read-only per-source graphic EQ state |
+| `EQv2GetList:http://moddevices.com/plugins/caps/Eq10HP` | `client.get_graphic_eq_preset_list()` | `dict[str, list[str]]` | Read-only graphic EQ preset names |
+| `RoomCorrGet` | `client.get_room_correction()` | `RoomCorrectionSettings` | Read-only room-correction state |
+
+Write commands for graphic EQ and room correction are intentionally not exposed
+yet. Use the WiiM app for setup/configuration until write behavior is validated
+across more models and firmware versions.
+
+## Intentionally Not Exposed
+
+One-off setup, account, network, update-server, token, static-IP, Wi-Fi, Alexa,
+and factory-reset style commands from the app bundle are not good Home
+Assistant surfaces. pywiim may keep selected read-only diagnostics over time,
+but user-facing HA entities/services should focus on daily listening and
+automation workflows.
 
 ## Real-Device Testing
 

--- a/docs/integration/API_REFERENCE.md
+++ b/docs/integration/API_REFERENCE.md
@@ -318,11 +318,33 @@ await player.client.load_peq("My Preset", source_name="wifi")
 
 **Data models** (from `pywiim.api.peq`): `PEQBand`, `PEQSettings`, `PEQPresetInfo`. Constants: `PEQ_MODE_OFF`, `PEQ_MODE_LOW_SHELF`, `PEQ_MODE_PEAK`, `PEQ_MODE_HIGH_SHELF`, `PEQ_CHANNEL_MODE_STEREO`, `PEQ_CHANNEL_MODE_LR`.
 
-##### LV2 graphic 10-band EQ (`Eq10HP`) — documented only
+##### LV2 graphic 10-band EQ (`Eq10HP`) — WiiM only, read-only
 
 WiiM firmware can also load a **10-band graphic** LV2 plugin (**`http://moddevices.com/plugins/caps/Eq10HP`**) for per-source EQ. Reports indicate the **same HTTP command family** as above (`EQGetLV2SourceBandEx`, `EQSetLV2SourceBand`, `EQChangeSourceFX`, etc.), but with **`pluginURI`** set to **`http://moddevices.com/plugins/caps/Eq10HP`** and band parameters such as `band31hz`, `band63hz`, … instead of the parametric `a_mode` / `a_freq` / … shape used by **`EqNp`**.
 
-**pywiim does not implement `Eq10HP`:** there are no client helpers or parsers for that plugin; `PEQAPI` is built exclusively around **`EqNp`**. Integrators who need graphic LV2 EQ must call the device with the **Eq10HP** `pluginURI` and payload layout themselves. Community field note: [GitHub issue #16](https://github.com/mjcumming/pywiim/issues/16).
+pywiim exposes read-only helpers for this plugin. Use the WiiM app for setup/write workflows until write behavior is validated across more firmware versions.
+
+```python
+settings = await player.client.get_graphic_eq_bands()
+settings = await player.client.get_graphic_eq_bands(source_name="wifi")
+# settings: GraphicEQSettings (enabled, channel_mode, name, eq_level, bands)
+
+presets = await player.client.get_graphic_eq_preset_list()
+# {"custom": [...], "preset": ["Flat", "Acoustic", ...]}
+```
+
+**Data models** (from `pywiim.api.peq`): `GraphicEQBand`, `GraphicEQSettings`. Constant: `GEQ_PLUGIN_URI`.
+
+##### Room Correction — WiiM only, read-only
+
+WiiM firmware exposes a room-correction block through `RoomCorrGet`. The payload is PEQ-shaped (`EqNp` plugin parameters), but it represents the device's room-correction state rather than the user PEQ preset.
+
+```python
+room = await player.client.get_room_correction()
+# room: RoomCorrectionSettings (enabled, channel_mode, name, eq_level, bands)
+```
+
+pywiim intentionally exposes room correction as **read-only** for now. Use the WiiM app to create or adjust room correction until `RoomCorrSet` / `RoomCorrSetLR` have broad real-device coverage.
 
 #### Playback Presets (Radio Stations / Saved Favorites)
 

--- a/docs/testing/CURL_HTTPAPI.md
+++ b/docs/testing/CURL_HTTPAPI.md
@@ -46,10 +46,13 @@ These are **GET**-style URLs (read-only). Good for baselines before/after you ch
 | `getPlayerStatusEx` | Richer playback JSON (when supported) |
 | `getMetaInfo` | Track metadata (may be empty on some sources) |
 | `getAudioInputEnable` | WiiM input enablement metadata; see [WiiM Discovered Read-Only APIs](../design/WIIM_DISCOVERED_APIS.md). |
+| `getAudioInputCapbility` | WiiM input capability metadata. Firmware spelling is `Capbility`. |
 | `getModeRename` | WiiM user-renamed input labels; may return plain `Failed` when no labels are renamed. |
 | `GetAcousticCapability` | WiiM acoustic capability blocks (GEQ/PEQ/RC/output delay/etc.). |
 | `getAllRoutines` | WiiM routines (device-side action sequences, not playback presets). |
 | `getSoundCardModeSupportList` | WiiM output sound-card support list; key by `mode`, not `index`. |
+| `RoomCorrGet` | WiiM room-correction state; read-only in pywiim. |
+| `EQv2GetList:http://moddevices.com/plugins/caps/Eq10HP` | WiiM graphic EQ preset names. |
 
 Examples:
 
@@ -69,10 +72,15 @@ curl -ks "https://${DEVICE}:443/httpapi.asp?command=getAudioOutputStatus"
 
 # WiiM-only research endpoints from pywiim#20
 curl -ks "https://${DEVICE}:443/httpapi.asp?command=getAudioInputEnable" | python3 -m json.tool
+curl -ks "https://${DEVICE}:443/httpapi.asp?command=getAudioInputCapbility" | python3 -m json.tool
 curl -ks "https://${DEVICE}:443/httpapi.asp?command=getModeRename" | python3 -m json.tool
 curl -ks "https://${DEVICE}:443/httpapi.asp?command=GetAcousticCapability" | python3 -m json.tool
 curl -ks "https://${DEVICE}:443/httpapi.asp?command=getAllRoutines" | python3 -m json.tool
 curl -ks "https://${DEVICE}:443/httpapi.asp?command=getSoundCardModeSupportList" | python3 -m json.tool
+
+# Daily-use EQ research endpoints (read-only)
+curl -ks "https://${DEVICE}:443/httpapi.asp?command=RoomCorrGet" | python3 -m json.tool
+curl -ks "https://${DEVICE}:443/httpapi.asp?command=EQv2GetList:http://moddevices.com/plugins/caps/Eq10HP" | python3 -m json.tool
 ```
 
 **Note:** Output field meanings (`hardware`, `source`, `audiocast`) for the **JSON object** are documented in [API_DESIGN_PATTERNS.md](../design/API_DESIGN_PATTERNS.md). pywiim probes **`getNewAudioOutputHardwareMode` first**, then **`getAudioOutputStatus`**, matching real firmware differences (see [mjcumming/wiim#144](https://github.com/mjcumming/wiim/issues/144) and `WiiMCapabilities.detect_capabilities` in `pywiim/capabilities.py`).

--- a/pywiim/__init__.py
+++ b/pywiim/__init__.py
@@ -30,6 +30,7 @@ from .api.constants import (
     ALARM_TRIGGER_ONCE,
     ALARM_TRIGGER_WEEKLY,
     ALARM_TRIGGER_WEEKLY_BITMASK,
+    GEQ_PLUGIN_URI,
     PEQ_CHANNEL_MODE_LR,
     PEQ_CHANNEL_MODE_STEREO,
     PEQ_DEFAULT_FREQUENCIES,
@@ -53,7 +54,7 @@ from .api.constants import (
     SUBWOOFER_PHASE_0,
     SUBWOOFER_PHASE_180,
 )
-from .api.peq import PEQBand, PEQPresetInfo, PEQSettings
+from .api.peq import GraphicEQBand, GraphicEQSettings, PEQBand, PEQPresetInfo, PEQSettings, RoomCorrectionSettings
 from .api.subwoofer import SubwooferStatus
 from .backoff import BackoffController
 from .client import WiiMClient
@@ -77,6 +78,8 @@ from .group import Group
 from .group_helpers import build_group_state_from_players
 from .models import (
     AcousticCapability,
+    AudioInputCapability,
+    AudioInputCapabilityItem,
     AudioInputEnable,
     AudioInputEnableItem,
     DeviceInfo,
@@ -120,6 +123,8 @@ __all__ = [
     "PlayerStatus",
     "AudioInputEnableItem",
     "AudioInputEnable",
+    "AudioInputCapabilityItem",
+    "AudioInputCapability",
     "AcousticCapability",
     "RoutineStep",
     "Routine",
@@ -177,7 +182,11 @@ __all__ = [
     "PEQBand",
     "PEQSettings",
     "PEQPresetInfo",
+    "GraphicEQBand",
+    "GraphicEQSettings",
+    "RoomCorrectionSettings",
     "PEQ_PLUGIN_URI",
+    "GEQ_PLUGIN_URI",
     "PEQ_MODE_OFF",
     "PEQ_MODE_LOW_SHELF",
     "PEQ_MODE_PEAK",

--- a/pywiim/api/constants.py
+++ b/pywiim/api/constants.py
@@ -399,6 +399,7 @@ DISPLAY_BRIGHTNESS_MIN = 1
 DISPLAY_BRIGHTNESS_MAX = 100
 DISPLAY_DEFAULT_BRIGHTNESS = 100
 API_ENDPOINT_GET_AUDIO_INPUT_ENABLE = "/httpapi.asp?command=getAudioInputEnable"
+API_ENDPOINT_GET_AUDIO_INPUT_CAPABILITY = "/httpapi.asp?command=getAudioInputCapbility"
 API_ENDPOINT_GET_MODE_RENAME = "/httpapi.asp?command=getModeRename"
 API_ENDPOINT_GET_ACOUSTIC_CAPABILITY = "/httpapi.asp?command=GetAcousticCapability"
 API_ENDPOINT_GET_ALL_ROUTINES = "/httpapi.asp?command=getAllRoutines"
@@ -441,10 +442,9 @@ API_ENDPOINT_SUBWOOFER_SET = "/httpapi.asp?command=setSubLPF:"
 API_ENDPOINT_TRIGGER_OUT_STATUS = "/httpapi.asp?command=getTriggeroutStatus"
 API_ENDPOINT_TRIGGER_OUT_SET = "/httpapi.asp?command=setTriggeroutStatus:"
 
-# PEQ (Parametric Equalizer) endpoints - official WiiM LV2 PEQ API
+# PEQ / GEQ endpoints - official WiiM LV2 EQ API
 # pluginURI (implemented in pywiim): http://moddevices.com/plugins/caps/EqNp
-# Same endpoints also accept other LV2 plugins (e.g. graphic 10-band Eq10HP);
-# pywiim does not implement Eq10HP — see docs/integration/API_REFERENCE.md (PEQ section).
+# graphic 10-band pluginURI: http://moddevices.com/plugins/caps/Eq10HP
 API_ENDPOINT_PEQ_GET_BAND = "/httpapi.asp?command=EQGetLV2BandEx:"
 API_ENDPOINT_PEQ_GET_SOURCE_BAND = "/httpapi.asp?command=EQGetLV2SourceBandEx:"
 API_ENDPOINT_PEQ_SET_BAND = "/httpapi.asp?command=EQSetLV2Band:"
@@ -464,6 +464,13 @@ API_ENDPOINT_PEQ_SET_CHANNEL_MODE = "/httpapi.asp?command=EQSetChannelMode:"
 
 # PEQ plugin URI (Parametric Equalizer)
 PEQ_PLUGIN_URI = "http://moddevices.com/plugins/caps/EqNp"
+
+# GEQ plugin URI (Graphic 10-band Equalizer)
+GEQ_PLUGIN_URI = "http://moddevices.com/plugins/caps/Eq10HP"
+
+# Room correction read endpoint. Uses the PEQ-shaped EqNp LV2 payload, but it is
+# a distinct device-side correction block rather than the user PEQ preset.
+API_ENDPOINT_ROOM_CORRECTION_GET = "/httpapi.asp?command=RoomCorrGet"
 
 # PEQ band letters (10 active bands: a-j; k-l exist but default to Off)
 PEQ_BAND_LETTERS = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")

--- a/pywiim/api/misc.py
+++ b/pywiim/api/misc.py
@@ -21,11 +21,12 @@ from urllib.parse import quote
 from pydantic import ValidationError
 
 from ..exceptions import WiiMError
-from ..models import AcousticCapability, AudioInputEnable, RoutineList
+from ..models import AcousticCapability, AudioInputCapability, AudioInputEnable, RoutineList
 from .constants import (
     API_ENDPOINT_DISPLAY_CONFIG,
     API_ENDPOINT_GET_ACOUSTIC_CAPABILITY,
     API_ENDPOINT_GET_ALL_ROUTINES,
+    API_ENDPOINT_GET_AUDIO_INPUT_CAPABILITY,
     API_ENDPOINT_GET_AUDIO_INPUT_ENABLE,
     API_ENDPOINT_GET_LED_MCU,
     API_ENDPOINT_GET_LED_SWITCH,
@@ -75,6 +76,21 @@ class MiscAPI:
             result = await self._request(API_ENDPOINT_GET_AUDIO_INPUT_ENABLE)  # type: ignore[attr-defined]
             if isinstance(result.parsed, dict) and not _is_unsupported_discovered_payload(result.parsed):
                 return AudioInputEnable.model_validate(result.parsed)
+        except (ValidationError, WiiMError):
+            return None
+        return None
+
+    async def get_audio_input_capability(self) -> AudioInputCapability | None:
+        """Return WiiM input capability metadata, if available.
+
+        The firmware command is named ``getAudioInputCapbility`` (misspelled).
+        It returns available input modes without enable/disable state. This is
+        read-only and expected to be absent on many non-WiiM LinkPlay devices.
+        """
+        try:
+            result = await self._request(API_ENDPOINT_GET_AUDIO_INPUT_CAPABILITY)  # type: ignore[attr-defined]
+            if isinstance(result.parsed, dict) and not _is_unsupported_discovered_payload(result.parsed):
+                return AudioInputCapability.model_validate(result.parsed)
         except (ValidationError, WiiMError):
             return None
         return None

--- a/pywiim/api/peq.py
+++ b/pywiim/api/peq.py
@@ -59,6 +59,8 @@ from .constants import (
     API_ENDPOINT_PEQ_SOURCE_LOAD,
     API_ENDPOINT_PEQ_SOURCE_OFF,
     API_ENDPOINT_PEQ_SOURCE_SAVE,
+    API_ENDPOINT_ROOM_CORRECTION_GET,
+    GEQ_PLUGIN_URI,
     PEQ_BAND_LETTERS,
     PEQ_CHANNEL_MODE_LR,
     PEQ_CHANNEL_MODE_STEREO,
@@ -87,6 +89,9 @@ __all__ = [
     "PEQBand",
     "PEQSettings",
     "PEQPresetInfo",
+    "GraphicEQBand",
+    "GraphicEQSettings",
+    "RoomCorrectionSettings",
     "PEQ_MODE_OFF",
     "PEQ_MODE_LOW_SHELF",
     "PEQ_MODE_PEAK",
@@ -94,6 +99,19 @@ __all__ = [
     "PEQ_CHANNEL_MODE_STEREO",
     "PEQ_CHANNEL_MODE_LR",
 ]
+
+GEQ_BAND_NAMES = (
+    "band31hz",
+    "band63hz",
+    "band125hz",
+    "band250hz",
+    "band500hz",
+    "band1khz",
+    "band2khz",
+    "band4khz",
+    "band8khz",
+    "band16khz",
+)
 
 
 @dataclass
@@ -190,6 +208,39 @@ class PEQPresetInfo:
     preset_type: str = "Custom"
 
 
+@dataclass
+class GraphicEQBand:
+    """One band from WiiM's LV2 10-band graphic EQ plugin."""
+
+    name: str
+    gain: float = 0.0
+
+
+@dataclass
+class GraphicEQSettings:
+    """Settings for WiiM's LV2 10-band graphic EQ plugin (Eq10HP)."""
+
+    source_name: str = ""
+    enabled: bool = False
+    channel_mode: str = PEQ_CHANNEL_MODE_STEREO
+    name: str = ""
+    eq_level: int | None = None
+    bands: list[GraphicEQBand] = field(default_factory=list)
+
+
+@dataclass
+class RoomCorrectionSettings:
+    """Read-only room-correction settings from ``RoomCorrGet``."""
+
+    source_name: str = ""
+    enabled: bool = False
+    channel_mode: str = PEQ_CHANNEL_MODE_STEREO
+    name: str = ""
+    eq_level: int | None = None
+    plugin_uri: str = PEQ_PLUGIN_URI
+    bands: list[PEQBand] = field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -217,6 +268,58 @@ def _parse_eq_band_array(band_array: list[dict[str, Any]]) -> list[PEQBand]:
         band = PEQBand.from_api_params(letter, param_map)
         bands.append(band)
     return bands
+
+
+def _parse_graphic_eq_band_array(band_array: list[dict[str, Any]]) -> list[GraphicEQBand]:
+    """Parse Eq10HP band array into stable 10-band graphic EQ objects."""
+    gains: dict[str, float] = {}
+    for entry in band_array:
+        pname = entry.get("param_name")
+        val = entry.get("value")
+        if pname and val is not None:
+            try:
+                gains[str(pname)] = float(val)
+            except (ValueError, TypeError):
+                _LOGGER.debug("GEQ: skipping unreadable param %r = %r", pname, val)
+
+    return [GraphicEQBand(name=name, gain=gains.get(name, 0.0)) for name in GEQ_BAND_NAMES]
+
+
+def _parse_graphic_eq_settings(raw: dict[str, Any]) -> GraphicEQSettings:
+    """Convert a raw Eq10HP API response into :class:`GraphicEQSettings`."""
+    eq_level = raw.get("EQLevel")
+    try:
+        parsed_eq_level = int(eq_level) if eq_level is not None else None
+    except (TypeError, ValueError):
+        parsed_eq_level = None
+
+    return GraphicEQSettings(
+        source_name=str(raw.get("source_name", "")),
+        enabled=str(raw.get("EQStat", "Off")).strip().lower() == "on",
+        channel_mode=str(raw.get("channelMode", PEQ_CHANNEL_MODE_STEREO)),
+        name=str(raw.get("Name", "")),
+        eq_level=parsed_eq_level,
+        bands=_parse_graphic_eq_band_array(raw.get("EQBand", [])),
+    )
+
+
+def _parse_room_correction_settings(raw: dict[str, Any]) -> RoomCorrectionSettings:
+    """Convert a raw RoomCorrGet response into :class:`RoomCorrectionSettings`."""
+    eq_level = raw.get("EQLevel")
+    try:
+        parsed_eq_level = int(eq_level) if eq_level is not None else None
+    except (TypeError, ValueError):
+        parsed_eq_level = None
+
+    return RoomCorrectionSettings(
+        source_name=str(raw.get("source_name", "")),
+        enabled=str(raw.get("EQStat", "Off")).strip().lower() == "on",
+        channel_mode=str(raw.get("channelMode", PEQ_CHANNEL_MODE_STEREO)),
+        name=str(raw.get("Name", "")),
+        eq_level=parsed_eq_level,
+        plugin_uri=str(raw.get("pluginURI", PEQ_PLUGIN_URI)),
+        bands=_parse_eq_band_array(raw.get("EQBand", [])),
+    )
 
 
 def _encode_json_param(payload: dict[str, Any]) -> str:
@@ -289,6 +392,45 @@ class PEQAPI:
 
         raw = await self._request(endpoint)  # type: ignore[attr-defined]
         return _parse_peq_settings(raw.parsed if isinstance(raw.parsed, dict) else {})
+
+    async def get_graphic_eq_bands(self, source_name: str | None = None) -> GraphicEQSettings:
+        """Get WiiM LV2 graphic 10-band EQ settings.
+
+        This targets the ``Eq10HP`` LV2 plugin used by WiiM's graphic EQ. It is
+        read-only for now; use the WiiM app for setup until write behavior is
+        tested across more firmware versions.
+        """
+        self._require_peq()
+        _LOGGER.debug("get_graphic_eq_bands source=%s", source_name)
+        if source_name is not None:
+            payload = {"source_name": source_name, "pluginURI": GEQ_PLUGIN_URI}
+            endpoint = API_ENDPOINT_PEQ_GET_SOURCE_BAND + _encode_json_param(payload)
+        else:
+            endpoint = API_ENDPOINT_PEQ_GET_BAND + quote(GEQ_PLUGIN_URI, safe="")
+
+        raw = await self._request(endpoint)  # type: ignore[attr-defined]
+        return _parse_graphic_eq_settings(raw.parsed if isinstance(raw.parsed, dict) else {})
+
+    async def get_graphic_eq_preset_list(self) -> dict[str, list[str]]:
+        """Get all custom and preset names for the WiiM graphic EQ plugin."""
+        self._require_peq()
+        endpoint = API_ENDPOINT_PEQ_GET_LIST + quote(GEQ_PLUGIN_URI, safe="")
+        raw = await self._request(endpoint)  # type: ignore[attr-defined]
+        data = raw.parsed if isinstance(raw.parsed, dict) else {}
+        return {
+            "custom": list(data.get("custom", [])),
+            "preset": list(data.get("preset", [])),
+        }
+
+    async def get_room_correction(self) -> RoomCorrectionSettings:
+        """Get WiiM room-correction settings.
+
+        The payload is PEQ-shaped but belongs to the device's room-correction
+        block, not the user PEQ preset. This helper is intentionally read-only.
+        """
+        self._require_peq()
+        raw = await self._request(API_ENDPOINT_ROOM_CORRECTION_GET)  # type: ignore[attr-defined]
+        return _parse_room_correction_settings(raw.parsed if isinstance(raw.parsed, dict) else {})
 
     # ------------------------------------------------------------------
     # Tune (set)

--- a/pywiim/cli/diagnostics.py
+++ b/pywiim/cli/diagnostics.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import sys
+from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from typing import Any
 
@@ -190,12 +191,19 @@ class DeviceDiagnostics:
         discovered: dict[str, Any] = {}
 
         async def probe(name: str, func: Any) -> None:
+            def serialize_probe_value(item: Any) -> Any:
+                if hasattr(item, "model_dump"):
+                    return item.model_dump()
+                if is_dataclass(item):
+                    return asdict(item)
+                return item
+
             try:
                 value = await func()
-                if hasattr(value, "model_dump"):
-                    value = value.model_dump()
+                if hasattr(value, "model_dump") or is_dataclass(value):
+                    value = serialize_probe_value(value)
                 elif isinstance(value, list):
-                    value = [item.model_dump() if hasattr(item, "model_dump") else item for item in value]
+                    value = [serialize_probe_value(item) for item in value]
                 discovered[name] = {
                     "supported": value is not None and value != [],
                     "value": value,
@@ -211,10 +219,14 @@ class DeviceDiagnostics:
                 print(f"   ⚠ {name}: {err}")
 
         await probe("getAudioInputEnable", self.client.get_audio_input_enable)
+        await probe("getAudioInputCapbility", self.client.get_audio_input_capability)
         await probe("getModeRename", self.client.get_mode_rename)
         await probe("GetAcousticCapability", self.client.get_acoustic_capability)
         await probe("getAllRoutines", self.client.get_all_routines)
         await probe("getSoundCardModeSupportList", self.client.get_sound_card_mode_support_list)
+        await probe("Eq10HP", self.client.get_graphic_eq_bands)
+        await probe("Eq10HPPresetList", self.client.get_graphic_eq_preset_list)
+        await probe("RoomCorrGet", self.client.get_room_correction)
 
         self.report["discovered_apis"] = discovered
 
@@ -279,6 +291,8 @@ class DeviceDiagnostics:
             ("LED Indicator", self._test_led_indicator),
             ("Display", self._test_display),
             ("PEQ (Advanced EQ)", self._test_peq),
+            ("Graphic EQ", self._test_graphic_eq),
+            ("Room Correction", self._test_room_correction),
         ]
 
         self.report["features"] = {}
@@ -419,6 +433,20 @@ class DeviceDiagnostics:
                             print(f"         - {p}")
                         if len(preset) > 10:
                             print(f"         ... and {len(preset) - 10} more")
+
+                # Special handling for Graphic EQ
+                if name == "Graphic EQ" and result.get("supported"):
+                    print(f"      Current preset: {result.get('name') or 'Unknown'}")
+                    print(f"      Enabled: {result.get('enabled')}")
+                    print(f"      Bands: {result.get('band_count', 0)}")
+                    preset = result.get("preset_names", [])
+                    print(f"      Built-in presets: {len(preset)}")
+
+                # Special handling for Room Correction
+                if name == "Room Correction" and result.get("supported"):
+                    print(f"      Enabled: {result.get('enabled')}")
+                    print(f"      Source: {result.get('source_name') or 'Unknown'}")
+                    print(f"      Bands: {result.get('band_count', 0)}")
             except Exception as err:
                 self.report["features"][name] = {
                     "supported": False,
@@ -738,6 +766,50 @@ class DeviceDiagnostics:
         except Exception as err:
             return {"supported": False, "error": str(err)}
 
+    async def _test_graphic_eq(self) -> dict[str, Any]:
+        """Test read-only WiiM LV2 graphic EQ (Eq10HP)."""
+        try:
+            if not self.client.capabilities.get("supports_peq", False):
+                return {"supported": False, "reason": "Graphic EQ not supported (WiiM only)"}
+            settings = await self.client.get_graphic_eq_bands()
+            preset_list = await self.client.get_graphic_eq_preset_list()
+            return {
+                "supported": True,
+                "enabled": settings.enabled,
+                "name": settings.name,
+                "source_name": settings.source_name,
+                "eq_level": settings.eq_level,
+                "band_count": len(settings.bands),
+                "bands": [asdict(band) for band in settings.bands],
+                "custom_presets": list(preset_list.get("custom", [])),
+                "preset_names": list(preset_list.get("preset", [])),
+            }
+        except WiiMError:
+            return {"supported": False, "reason": "Graphic EQ not available"}
+        except Exception as err:
+            return {"supported": False, "error": str(err)}
+
+    async def _test_room_correction(self) -> dict[str, Any]:
+        """Test read-only WiiM room-correction state."""
+        try:
+            if not self.client.capabilities.get("supports_peq", False):
+                return {"supported": False, "reason": "Room correction not supported (WiiM only)"}
+            settings = await self.client.get_room_correction()
+            return {
+                "supported": True,
+                "enabled": settings.enabled,
+                "name": settings.name,
+                "source_name": settings.source_name,
+                "eq_level": settings.eq_level,
+                "plugin_uri": settings.plugin_uri,
+                "band_count": len(settings.bands),
+                "bands": [asdict(band) for band in settings.bands],
+            }
+        except WiiMError:
+            return {"supported": False, "reason": "Room correction not available"}
+        except Exception as err:
+            return {"supported": False, "error": str(err)}
+
     def _generate_summary(self) -> dict[str, Any]:
         """Generate diagnostic summary."""
         device = self.report.get("device", {})
@@ -946,6 +1018,18 @@ class DeviceDiagnostics:
                 self.report["peq"] = {"supported": False}
         except Exception:
             self.report["peq"] = {"supported": False}
+
+        # Add Graphic EQ (Eq10HP) state if supported
+        try:
+            self.report["graphic_eq"] = await self._test_graphic_eq()
+        except Exception:
+            self.report["graphic_eq"] = {"supported": False}
+
+        # Add room-correction state if supported
+        try:
+            self.report["room_correction"] = await self._test_room_correction()
+        except Exception:
+            self.report["room_correction"] = {"supported": False}
 
         # Generate summary
         self.report["summary"] = self._generate_summary()

--- a/pywiim/cli/verify_cli.py
+++ b/pywiim/cli/verify_cli.py
@@ -10,6 +10,7 @@ import argparse
 import asyncio
 import json
 import sys
+from dataclasses import asdict
 from typing import Any
 
 from ..client import WiiMClient
@@ -812,6 +813,82 @@ class FeatureTester:
             self.results["failed"].append(f"eq: Error - {str(e)}")
             print(f"   ✗ Error: {e}")
 
+    async def test_advanced_eq_readonly(self) -> None:
+        """Test advanced WiiM EQ read-only endpoints."""
+        print("\n🎚️  Testing Advanced EQ Read-Only APIs...")
+
+        if not self.client.capabilities.get("supports_peq", False):
+            self.results["skipped"].append("advanced_eq: Not supported")
+            print("   ⊘ Advanced EQ not supported")
+            return
+
+        try:
+            peq_presets = await self.client.get_peq_preset_list()
+            self.results["passed"].append("advanced_eq: get_peq_preset_list")
+            print(
+                "   ✓ get_peq_preset_list "
+                f"({len(peq_presets.get('preset', []))} built-in, {len(peq_presets.get('custom', []))} custom)"
+            )
+            self._print_data("PEQ Presets", peq_presets, show_always=True)
+        except Exception as e:
+            self.results["warnings"].append(f"advanced_eq: get_peq_preset_list - {str(e)}")
+            print(f"   ⚠️  get_peq_preset_list: {e}")
+
+        try:
+            graphic_eq = await self.client.get_graphic_eq_bands()
+            self.results["passed"].append("advanced_eq: get_graphic_eq_bands")
+            print(
+                "   ✓ get_graphic_eq_bands "
+                f"({len(graphic_eq.bands)} bands, preset={graphic_eq.name or 'Unknown'})"
+            )
+            self._print_data(
+                "Graphic EQ",
+                {
+                    "enabled": graphic_eq.enabled,
+                    "name": graphic_eq.name,
+                    "source_name": graphic_eq.source_name,
+                    "eq_level": graphic_eq.eq_level,
+                    "bands": [asdict(band) for band in graphic_eq.bands],
+                },
+                show_always=True,
+            )
+        except Exception as e:
+            self.results["warnings"].append(f"advanced_eq: get_graphic_eq_bands - {str(e)}")
+            print(f"   ⚠️  get_graphic_eq_bands: {e}")
+
+        try:
+            graphic_presets = await self.client.get_graphic_eq_preset_list()
+            self.results["passed"].append("advanced_eq: get_graphic_eq_preset_list")
+            print(
+                "   ✓ get_graphic_eq_preset_list "
+                f"({len(graphic_presets.get('preset', []))} built-in, "
+                f"{len(graphic_presets.get('custom', []))} custom)"
+            )
+            self._print_data("Graphic EQ Presets", graphic_presets, show_always=True)
+        except Exception as e:
+            self.results["warnings"].append(f"advanced_eq: get_graphic_eq_preset_list - {str(e)}")
+            print(f"   ⚠️  get_graphic_eq_preset_list: {e}")
+
+        try:
+            room = await self.client.get_room_correction()
+            self.results["passed"].append("advanced_eq: get_room_correction")
+            print(f"   ✓ get_room_correction ({len(room.bands)} bands, enabled={room.enabled})")
+            self._print_data(
+                "Room Correction",
+                {
+                    "enabled": room.enabled,
+                    "name": room.name,
+                    "source_name": room.source_name,
+                    "eq_level": room.eq_level,
+                    "plugin_uri": room.plugin_uri,
+                    "bands": [asdict(band) for band in room.bands],
+                },
+                show_always=True,
+            )
+        except Exception as e:
+            self.results["warnings"].append(f"advanced_eq: get_room_correction - {str(e)}")
+            print(f"   ⚠️  get_room_correction: {e}")
+
     async def test_preset_controls(self) -> None:
         """Test preset controls."""
         print("\n⭐ Testing Preset Controls...")
@@ -1150,6 +1227,7 @@ class FeatureTester:
         await self.test_source_controls()
         await self.test_audio_output()
         await self.test_eq_controls()
+        await self.test_advanced_eq_readonly()
         await self.test_preset_controls()
         await self.test_multiroom_controls()
         await self.test_bluetooth_controls()

--- a/pywiim/models.py
+++ b/pywiim/models.py
@@ -27,6 +27,8 @@ __all__ = [
     "DeviceGroupInfo",
     "AudioInputEnableItem",
     "AudioInputEnable",
+    "AudioInputCapabilityItem",
+    "AudioInputCapability",
     "AcousticCapability",
     "RoutineStep",
     "Routine",
@@ -301,6 +303,24 @@ class AudioInputEnable(_WiimBase):
 
     version: str | None = Field(None, alias="ver")
     audio_input: list[AudioInputEnableItem] = Field(default_factory=list, alias="audioInput")
+
+
+class AudioInputCapabilityItem(_WiimBase):
+    """One entry from WiiM ``getAudioInputCapbility``.
+
+    The command name is misspelled in firmware ("Capbility"). It returns source
+    modes that the device can expose, without the per-input enable flag returned
+    by ``getAudioInputEnable``.
+    """
+
+    mode: str
+
+
+class AudioInputCapability(_WiimBase):
+    """Payload from WiiM ``getAudioInputCapbility``."""
+
+    version: str | None = Field(None, alias="ver")
+    audio_input: list[AudioInputCapabilityItem] = Field(default_factory=list, alias="audioInput")
 
 
 class AcousticCapability(_WiimBase):

--- a/tests/unit/api/test_misc.py
+++ b/tests/unit/api/test_misc.py
@@ -66,6 +66,47 @@ class TestMiscAPI:
         assert await TestClient().get_audio_input_enable() is None
 
     @pytest.mark.asyncio
+    async def test_get_audio_input_capability(self):
+        """Test getAudioInputCapbility model parsing."""
+        from pywiim.api.constants import API_ENDPOINT_GET_AUDIO_INPUT_CAPABILITY
+        from pywiim.api.misc import MiscAPI
+
+        requests = []
+
+        class TestClient(MiscAPI):
+            async def _request(self, endpoint):
+                requests.append(endpoint)
+                return ApiResponse(
+                    parsed={
+                        "ver": "1.0",
+                        "audioInput": [
+                            {"mode": "wifi"},
+                            {"mode": "line-in"},
+                            {"mode": "bluetooth"},
+                        ],
+                    },
+                    raw=None,
+                )
+
+        result = await TestClient().get_audio_input_capability()
+
+        assert requests == [API_ENDPOINT_GET_AUDIO_INPUT_CAPABILITY]
+        assert result is not None
+        assert result.version == "1.0"
+        assert [item.mode for item in result.audio_input] == ["wifi", "line-in", "bluetooth"]
+
+    @pytest.mark.asyncio
+    async def test_get_audio_input_capability_unsupported(self):
+        """Unsupported getAudioInputCapbility returns None."""
+        from pywiim.api.misc import MiscAPI
+
+        class TestClient(MiscAPI):
+            async def _request(self, endpoint):
+                return ApiResponse(parsed={"raw": "unknown command", "error": "unsupported_command"}, raw=None)
+
+        assert await TestClient().get_audio_input_capability() is None
+
+    @pytest.mark.asyncio
     async def test_get_mode_rename(self):
         """Test getModeRename dynamic map parsing."""
         from pywiim.api.constants import API_ENDPOINT_GET_MODE_RENAME

--- a/tests/unit/api/test_peq.py
+++ b/tests/unit/api/test_peq.py
@@ -20,10 +20,14 @@ from pywiim.api.constants import (
     PEQ_MODE_PEAK,
 )
 from pywiim.api.peq import (
+    GraphicEQSettings,
     PEQBand,
     PEQSettings,
+    RoomCorrectionSettings,
     _parse_eq_band_array,
+    _parse_graphic_eq_settings,
     _parse_peq_settings,
+    _parse_room_correction_settings,
     _validate_channel_mode,
     _validate_frequency,
     _validate_gain,
@@ -195,6 +199,79 @@ class TestParsePeqSettings:
         assert len(settings.bands) == 10
 
 
+class TestParseGraphicEqSettings:
+    """Tests for Eq10HP graphic EQ parsing."""
+
+    def test_graphic_eq_response(self):
+        """Graphic EQ response returns 10 named gain bands."""
+        raw = {
+            "EQStat": "On",
+            "EQLevel": 1,
+            "source_name": "wifi",
+            "Name": "Acoustic",
+            "channelMode": PEQ_CHANNEL_MODE_STEREO,
+            "EQBand": [
+                {"param_name": "band31hz", "value": 5.0},
+                {"param_name": "band1khz", "value": 1.8},
+                {"param_name": "band16khz", "value": "2.2"},
+            ],
+        }
+
+        settings = _parse_graphic_eq_settings(raw)
+
+        assert isinstance(settings, GraphicEQSettings)
+        assert settings.enabled is True
+        assert settings.eq_level == 1
+        assert settings.source_name == "wifi"
+        assert settings.name == "Acoustic"
+        assert len(settings.bands) == 10
+        assert settings.bands[0].name == "band31hz"
+        assert settings.bands[0].gain == 5.0
+        assert settings.bands[5].name == "band1khz"
+        assert settings.bands[5].gain == 1.8
+        assert settings.bands[9].gain == 2.2
+
+    def test_graphic_eq_defaults(self):
+        """Missing graphic EQ bands default to 0 dB."""
+        settings = _parse_graphic_eq_settings({})
+
+        assert settings.enabled is False
+        assert len(settings.bands) == 10
+        assert all(band.gain == 0.0 for band in settings.bands)
+
+
+class TestParseRoomCorrectionSettings:
+    """Tests for RoomCorrGet parsing."""
+
+    def test_room_correction_response(self):
+        """Room correction response is parsed as a PEQ-shaped read-only block."""
+        raw = {
+            "EQStat": "On",
+            "EQLevel": 2,
+            "source_name": "default",
+            "Name": "Room",
+            "pluginURI": "http://moddevices.com/plugins/caps/EqNp",
+            "channelMode": PEQ_CHANNEL_MODE_STEREO,
+            "EQBand": [
+                {"param_name": "a_mode", "value": 1},
+                {"param_name": "a_freq", "value": 31.25},
+                {"param_name": "a_q", "value": 0.25},
+                {"param_name": "a_gain", "value": -2.5},
+            ],
+        }
+
+        settings = _parse_room_correction_settings(raw)
+
+        assert isinstance(settings, RoomCorrectionSettings)
+        assert settings.enabled is True
+        assert settings.eq_level == 2
+        assert settings.source_name == "default"
+        assert settings.name == "Room"
+        assert len(settings.bands) == 10
+        assert settings.bands[0].frequency == 31.25
+        assert settings.bands[0].gain == -2.5
+
+
 # ---------------------------------------------------------------------------
 # PEQAPI public methods (via mock_client)
 # ---------------------------------------------------------------------------
@@ -240,6 +317,82 @@ class TestGetPeqBands:
         mock_client._capabilities = {"supports_peq": False}
         with pytest.raises(WiiMError, match="supports_peq"):
             await mock_client.get_peq_bands()
+
+
+class TestGetGraphicEqBands:
+    """Tests for read-only Eq10HP graphic EQ helpers."""
+
+    @pytest.mark.asyncio
+    async def test_get_graphic_eq_bands_no_source(self, mock_client):
+        """get_graphic_eq_bands without source calls Eq10HP endpoint."""
+        raw = {
+            "EQStat": "On",
+            "channelMode": PEQ_CHANNEL_MODE_STEREO,
+            "EQBand": [{"param_name": "band31hz", "value": 1.0}],
+        }
+        mock_client._request = AsyncMock(return_value=ApiResponse(parsed=raw, raw=None))
+
+        result = await mock_client.get_graphic_eq_bands()
+
+        assert isinstance(result, GraphicEQSettings)
+        call_args = mock_client._request.call_args[0][0]
+        assert "EQGetLV2BandEx" in call_args
+        assert "Eq10HP" in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_graphic_eq_bands_with_source(self, mock_client):
+        """get_graphic_eq_bands with source calls source-scoped Eq10HP endpoint."""
+        mock_client._request = AsyncMock(return_value=ApiResponse(parsed={"EQBand": []}, raw=None))
+
+        result = await mock_client.get_graphic_eq_bands(source_name="wifi")
+
+        assert isinstance(result, GraphicEQSettings)
+        call_args = mock_client._request.call_args[0][0]
+        assert "EQGetLV2SourceBandEx" in call_args
+        assert "source_name" in call_args
+        assert "Eq10HP" in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_graphic_eq_preset_list(self, mock_client):
+        """get_graphic_eq_preset_list returns custom and preset names."""
+        mock_client._request = AsyncMock(
+            return_value=ApiResponse(parsed={"custom": ["Desk"], "preset": ["Flat", "Acoustic"]}, raw=None)
+        )
+
+        result = await mock_client.get_graphic_eq_preset_list()
+
+        assert result == {"custom": ["Desk"], "preset": ["Flat", "Acoustic"]}
+        call_args = mock_client._request.call_args[0][0]
+        assert "EQv2GetList" in call_args
+        assert "Eq10HP" in call_args
+
+
+class TestGetRoomCorrection:
+    """Tests for read-only room correction helper."""
+
+    @pytest.mark.asyncio
+    async def test_get_room_correction(self, mock_client):
+        """get_room_correction parses RoomCorrGet payload."""
+        mock_client._request = AsyncMock(
+            return_value=ApiResponse(
+                parsed={
+                    "EQStat": "On",
+                    "EQLevel": 2,
+                    "source_name": "default",
+                    "EQBand": [{"param_name": "a_gain", "value": -3.0}],
+                },
+                raw=None,
+            )
+        )
+
+        result = await mock_client.get_room_correction()
+
+        assert isinstance(result, RoomCorrectionSettings)
+        assert result.enabled is True
+        assert result.eq_level == 2
+        assert result.bands[0].gain == -3.0
+        call_args = mock_client._request.call_args[0][0]
+        assert "RoomCorrGet" in call_args
 
 
 class TestSetPeqBands:

--- a/tests/unit/cli/test_diagnostics_cli.py
+++ b/tests/unit/cli/test_diagnostics_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from pywiim.api.peq import GraphicEQBand, GraphicEQSettings, RoomCorrectionSettings
 from pywiim.cli.diagnostics import DeviceDiagnostics
 
 
@@ -19,10 +20,14 @@ class DummyClient:
         self._detect_capabilities = AsyncMock()
         self.get_debug_info = AsyncMock(return_value={})
         self.get_audio_input_enable = AsyncMock(return_value=None)
+        self.get_audio_input_capability = AsyncMock(return_value=None)
         self.get_mode_rename = AsyncMock(return_value=None)
         self.get_acoustic_capability = AsyncMock(return_value=None)
         self.get_all_routines = AsyncMock(return_value=None)
         self.get_sound_card_mode_support_list = AsyncMock(return_value=[])
+        self.get_graphic_eq_bands = AsyncMock(return_value=GraphicEQSettings())
+        self.get_graphic_eq_preset_list = AsyncMock(return_value={"custom": [], "preset": []})
+        self.get_room_correction = AsyncMock(return_value=RoomCorrectionSettings())
         self.capabilities = {
             "vendor": "wiim",
             "is_wiim_device": True,
@@ -106,15 +111,22 @@ async def test_gather_discovered_api_info_stores_read_only_probe_results(capsys)
     client = DummyClient()
     client.get_mode_rename = AsyncMock(return_value={"optical": "TV"})
     client.get_sound_card_mode_support_list = AsyncMock(return_value=[{"mode": "usb"}])
+    client.get_graphic_eq_bands = AsyncMock(
+        return_value=GraphicEQSettings(name="Flat", bands=[GraphicEQBand(name="band31hz", gain=0.0)])
+    )
     diagnostics = DeviceDiagnostics(client)  # type: ignore[arg-type]
 
     await diagnostics._gather_discovered_api_info()
 
     result = diagnostics.report["discovered_apis"]
     assert result["getAudioInputEnable"]["supported"] is False
+    assert result["getAudioInputCapbility"]["supported"] is False
     assert result["getModeRename"]["supported"] is True
     assert result["getModeRename"]["value"] == {"optical": "TV"}
     assert result["getSoundCardModeSupportList"]["supported"] is True
+    assert result["Eq10HP"]["supported"] is True
+    assert result["Eq10HP"]["value"]["name"] == "Flat"
+    assert result["RoomCorrGet"]["supported"] is True
     assert "Probing discovered WiiM APIs" in capsys.readouterr().out
 
 
@@ -161,3 +173,46 @@ async def test_channel_balance_feature_skipped_without_capability():
 
     assert result["supported"] is False
     client.get_channel_balance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_graphic_eq_feature_supported():
+    """_test_graphic_eq summarizes read-only graphic EQ state."""
+    client = DummyClient()
+    client.capabilities = {**client.capabilities, "supports_peq": True}
+    client.get_graphic_eq_bands = AsyncMock(
+        return_value=GraphicEQSettings(
+            enabled=True,
+            name="Acoustic",
+            bands=[GraphicEQBand(name="band31hz", gain=5.0)],
+        )
+    )
+    client.get_graphic_eq_preset_list = AsyncMock(return_value={"custom": [], "preset": ["Flat", "Acoustic"]})
+    diagnostics = DeviceDiagnostics(client)  # type: ignore[arg-type]
+
+    result = await diagnostics._test_graphic_eq()
+
+    assert result["supported"] is True
+    assert result["name"] == "Acoustic"
+    assert result["band_count"] == 1
+    assert result["preset_names"] == ["Flat", "Acoustic"]
+
+
+@pytest.mark.asyncio
+async def test_room_correction_feature_supported():
+    """_test_room_correction summarizes read-only room correction state."""
+    client = DummyClient()
+    client.capabilities = {**client.capabilities, "supports_peq": True}
+    client.get_room_correction = AsyncMock(
+        return_value=RoomCorrectionSettings(
+            enabled=False,
+            source_name="default",
+        )
+    )
+    diagnostics = DeviceDiagnostics(client)  # type: ignore[arg-type]
+
+    result = await diagnostics._test_room_correction()
+
+    assert result["supported"] is True
+    assert result["enabled"] is False
+    assert result["source_name"] == "default"


### PR DESCRIPTION
## Summary

Adds read-only WiiM daily-use and diagnostic API surfaces in pywiim:

- `get_audio_input_capability()` for firmware command `getAudioInputCapbility`
- read-only Eq10HP graphic EQ helpers and models
- read-only room-correction helper and model
- diagnostics and verify CLI coverage for the new probes
- API/design/testing documentation updates

## Why

These APIs came out of the WiiM app endpoint sweep and are useful for capability discovery, diagnostics, and future Home Assistant integration work. Write paths remain intentionally out of scope until behavior is validated more broadly.

## Validation

- `python -m pytest tests/unit/api/test_misc.py tests/unit/api/test_peq.py tests/unit/cli/test_diagnostics_cli.py -q`

Result: `89 passed`.